### PR TITLE
feat: API changes

### DIFF
--- a/.changeset/chatty-dogs-wonder.md
+++ b/.changeset/chatty-dogs-wonder.md
@@ -1,0 +1,5 @@
+---
+"dharma-core": minor
+---
+
+Event handler and defineActions arguments consolidated to an object

--- a/.changeset/dull-spiders-roll.md
+++ b/.changeset/dull-spiders-roll.md
@@ -1,0 +1,5 @@
+---
+"dharma-react": patch
+---
+
+jsdoc update

--- a/.changeset/eighty-terms-clap.md
+++ b/.changeset/eighty-terms-clap.md
@@ -1,0 +1,5 @@
+---
+"dharma-core": patch
+---
+
+onAttach is now invoked before the first listener subscribes

--- a/.changeset/solid-otters-fix.md
+++ b/.changeset/solid-otters-fix.md
@@ -1,0 +1,5 @@
+---
+"dharma-core": minor
+---
+
+Consolidated createStore arguments to one configuration object

--- a/.changeset/young-cases-smell.md
+++ b/.changeset/young-cases-smell.md
@@ -1,0 +1,5 @@
+---
+"dharma-core": minor
+---
+
+Added reset function to store event handlers

--- a/.changeset/yummy-pens-count.md
+++ b/.changeset/yummy-pens-count.md
@@ -1,0 +1,5 @@
+---
+"dharma-react": minor
+---
+
+useStore no longer returns store actions

--- a/README.md
+++ b/README.md
@@ -11,18 +11,24 @@ A simple and lightweight state management solution for JavaScript and TypeScript
 ```ts
 import { createStore } from "dharma-core";
 
-const store = createStore({ count: 0 }, ({ set }) => ({
-  increment: () => set((state) => ({ count: state.count + 1 })),
-  decrement: () => set((state) => ({ count: state.count - 1 })),
-}));
+const store = createStore({
+  initialState: { count: 0 },
+  defineActions: ({ set }) => ({
+    increment: () => set((state) => ({ count: state.count + 1 })),
+    decrement: () => set((state) => ({ count: state.count - 1 })),
+  }),
+});
+
+const { increment, decrement } = store.actions;
 
 // Subscribe to state changes
-store.subscribe((state) => console.log(state));
+const unsubscribe = store.subscribe((state) => console.log(state.count));
 // Update the state
-store.actions.increment();
+increment();
 // { count: 1 }
-store.actions.decrement();
+decrement();
 // { count: 0 }
+unsubscribe();
 ```
 
 ## With React
@@ -50,11 +56,13 @@ yarn add dharma-core dharma-react
 ```ts
 import { createStore } from "dharma-core";
 
-export const store = createStore({ count: 0 }, ({ set }) => ({
-  increment: () => set((state) => ({ count: state.count + 1 })),
-  decrement: () => set((state) => ({ count: state.count - 1 })),
-  reset: () => set({ count: 0 }),
-}));
+export const store = createStore({
+  initialState: { count: 0 },
+  defineActions: ({ set }) => ({
+    increment: () => set((state) => ({ count: state.count + 1 })),
+    decrement: () => set((state) => ({ count: state.count - 1 })),
+  }),
+});
 
 export const { increment, decrement, reset } = store.actions;
 ```
@@ -73,7 +81,6 @@ function Counter() {
       <div>{count}</div>
       <button onClick={decrement}>-</button>
       <button onClick={increment}>+</button>
-      <button onClick={reset}>Reset</button>
     </div>
   );
 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A simple and lightweight state management solution for JavaScript and TypeScript
 ```ts
 import { createStore } from "dharma-core";
 
-const store = createStore({ count: 0 }, (set) => ({
+const store = createStore({ count: 0 }, ({ set }) => ({
   increment: () => set((state) => ({ count: state.count + 1 })),
   decrement: () => set((state) => ({ count: state.count - 1 })),
 }));
@@ -50,7 +50,7 @@ yarn add dharma-core dharma-react
 ```ts
 import { createStore } from "dharma-core";
 
-export const store = createStore({ count: 0 }, (set) => ({
+export const store = createStore({ count: 0 }, ({ set }) => ({
   increment: () => set((state) => ({ count: state.count + 1 })),
   decrement: () => set((state) => ({ count: state.count - 1 })),
   reset: () => set({ count: 0 }),

--- a/README.md
+++ b/README.md
@@ -50,24 +50,23 @@ yarn add dharma-core dharma-react
 ```ts
 import { createStore } from "dharma-core";
 
-const store = createStore({ count: 0 }, (set) => ({
+export const store = createStore({ count: 0 }, (set) => ({
   increment: () => set((state) => ({ count: state.count + 1 })),
   decrement: () => set((state) => ({ count: state.count - 1 })),
   reset: () => set({ count: 0 }),
 }));
+
+export const { increment, decrement, reset } = store.actions;
 ```
 
 3. Use the store:
 
 ```tsx
 import { useStore } from "dharma-react";
-import { store } from "./store";
+import { decrement, increment, reset, store } from "./store";
 
 function Counter() {
-  const {
-    state: { count },
-    actions: { increment, decrement, reset },
-  } = useStore(store);
+  const { count } = useStore(store);
 
   return (
     <div>

--- a/apps/demo/src/components/examples/Async.tsx
+++ b/apps/demo/src/components/examples/Async.tsx
@@ -23,7 +23,7 @@ const fetchUsers = async () => {
 
 const store = createStore(
   { users: [], loading: true } as State,
-  (set) => ({
+  ({ set }) => ({
     refresh: async () => {
       set({ users: [], loading: true });
       const users = await fetchUsers();
@@ -31,7 +31,7 @@ const store = createStore(
     },
   }),
   {
-    onAttach: async (state, set) => {
+    onAttach: async ({ state, set }) => {
       if (state.users.length) {
         return;
       }

--- a/apps/demo/src/components/examples/Async.tsx
+++ b/apps/demo/src/components/examples/Async.tsx
@@ -21,25 +21,25 @@ const fetchUsers = async () => {
   return await response.json();
 };
 
-const store = createStore(
-  { users: [], loading: true } as State,
-  ({ set }) => ({
+const initialState: State = {
+  users: [],
+  loading: true,
+};
+
+const store = createStore({
+  initialState,
+  defineActions: ({ set }) => ({
     refresh: async () => {
       set({ users: [], loading: true });
       const users = await fetchUsers();
       set({ users: users, loading: false });
     },
   }),
-  {
-    onAttach: async ({ state, set }) => {
-      if (state.users.length) {
-        return;
-      }
-      const users = await fetchUsers();
-      set({ users: users, loading: false });
-    },
+  onAttach: async ({ set }) => {
+    const users = await fetchUsers();
+    set({ users: users, loading: false });
   },
-);
+});
 
 const { refresh } = store.actions;
 

--- a/apps/demo/src/components/examples/Async.tsx
+++ b/apps/demo/src/components/examples/Async.tsx
@@ -41,11 +41,10 @@ const store = createStore(
   },
 );
 
+const { refresh } = store.actions;
+
 export function Async() {
-  const {
-    state: { users, loading },
-    actions: { refresh },
-  } = useStore(store);
+  const { users, loading } = useStore(store);
 
   return (
     <div className="container-full w-fit">

--- a/apps/demo/src/components/examples/Context.tsx
+++ b/apps/demo/src/components/examples/Context.tsx
@@ -6,15 +6,18 @@ import { Input } from "../ui/input";
 
 // Create the store context
 const CounterStoreContext = createStoreContext((initialCount: number) =>
-  createStore({ count: initialCount, input: "" }, ({ set }) => ({
-    increment: () => set((state) => ({ count: state.count + 1 })),
-    decrement: () => set((state) => ({ count: state.count - 1 })),
-    setInput: (input: string) => set({ input }),
-  })),
+  createStore({
+    initialState: { count: initialCount, input: "" },
+    defineActions: ({ set }) => ({
+      increment: () => set((state) => ({ count: state.count + 1 })),
+      decrement: () => set((state) => ({ count: state.count - 1 })),
+      setInput: (input: string) => set({ input }),
+    }),
+  }),
 );
 
 const Example = ({ initialCount }: { initialCount: number }) => {
-  // Create an instance of the store. Make sure the store is not instantiated on every render.
+  // Create an instance of the store. Make sure the store is not recreated on every render.
   const store = useMemo(
     () => CounterStoreContext.createStore(initialCount),
     [initialCount],

--- a/apps/demo/src/components/examples/Context.tsx
+++ b/apps/demo/src/components/examples/Context.tsx
@@ -6,7 +6,7 @@ import { Input } from "../ui/input";
 
 // Create the store context
 const CounterStoreContext = createStoreContext((initialCount: number) =>
-  createStore({ count: initialCount, input: "" }, (set) => ({
+  createStore({ count: initialCount, input: "" }, ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
     setInput: (input: string) => set({ input }),

--- a/apps/demo/src/components/examples/Context.tsx
+++ b/apps/demo/src/components/examples/Context.tsx
@@ -2,32 +2,26 @@ import { createStore } from "dharma-core";
 import { createStoreContext, useStore, useStoreContext } from "dharma-react";
 import { useMemo } from "react";
 import { Button } from "../ui/button";
+import { Input } from "../ui/input";
 
 // Create the store context
 const CounterStoreContext = createStoreContext((initialCount: number) =>
-  createStore(
-    { count: initialCount, isEven: initialCount % 2 === 0 },
-    (set) => ({
-      increment: () => set((state) => ({ count: state.count + 1 })),
-      decrement: () => set((state) => ({ count: state.count - 1 })),
-    }),
-    {
-      onChange: (state, set) => set({ isEven: state.count % 2 === 0 }),
-    },
-  ),
+  createStore({ count: initialCount, input: "" }, (set) => ({
+    increment: () => set((state) => ({ count: state.count + 1 })),
+    decrement: () => set((state) => ({ count: state.count - 1 })),
+    setInput: (input: string) => set({ input }),
+  })),
 );
 
-export const Counter = ({ initialCount }: { initialCount: number }) => {
+const Example = ({ initialCount }: { initialCount: number }) => {
   // Create an instance of the store. Make sure the store is not instantiated on every render.
   const store = useMemo(
     () => CounterStoreContext.createStore(initialCount),
     [initialCount],
   );
+  const { increment, decrement } = store.actions;
   // Use the store
-  const {
-    state: count,
-    actions: { increment, decrement },
-  } = useStore(store, (state) => state.count);
+  const count = useStore(store, (state) => state.count);
 
   return (
     // Provide the store to the context
@@ -37,34 +31,35 @@ export const Counter = ({ initialCount }: { initialCount: number }) => {
         <div aria-label="count">{count}</div>
         <Button onClick={increment}>+</Button>
       </div>
-      <DoubleCounter />
+      <TextInput />
     </CounterStoreContext>
   );
 };
 
-const DoubleCounter = () => {
-  // Access the store from the context
-  const { state: isEven } = useStoreContext(
-    CounterStoreContext,
-    (state) => state.isEven,
-  );
+const TextInput = () => {
+  const {
+    state: input,
+    actions: { setInput },
+  } = useStoreContext(CounterStoreContext, (state) => state.input);
 
   return (
-    <div className="text-sm" aria-label="double">
-      {isEven ? "Even" : "Odd"}
-    </div>
+    <Input
+      value={input}
+      onChange={(e) => setInput(e.target.value)}
+      placeholder="Type something..."
+    />
   );
 };
 
 export const Context = () => (
   <div className="container-full w-fit">
     <div className="container-full card">
-      <h2 className="font-bold">Counter 1</h2>
-      <Counter initialCount={0} />
+      <h2 className="font-bold">Context 1</h2>
+      <Example initialCount={0} />
     </div>
     <div className="container-full card">
-      <h2 className="font-bold">Counter 2</h2>
-      <Counter initialCount={5} />
+      <h2 className="font-bold">Context 2</h2>
+      <Example initialCount={5} />
     </div>
   </div>
 );

--- a/apps/demo/src/components/examples/Counter.tsx
+++ b/apps/demo/src/components/examples/Counter.tsx
@@ -3,10 +3,13 @@ import { useStore } from "dharma-react";
 import { Button } from "../ui/button";
 
 // Create the store
-const store = createStore({ count: 0 }, ({ set }) => ({
-  increment: () => set((state) => ({ count: state.count + 1 })),
-  decrement: () => set((state) => ({ count: state.count - 1 })),
-}));
+const store = createStore({
+  initialState: { count: 0 },
+  defineActions: ({ set }) => ({
+    increment: () => set((state) => ({ count: state.count + 1 })),
+    decrement: () => set((state) => ({ count: state.count - 1 })),
+  }),
+});
 
 const { increment, decrement } = store.actions;
 

--- a/apps/demo/src/components/examples/Counter.tsx
+++ b/apps/demo/src/components/examples/Counter.tsx
@@ -8,12 +8,11 @@ const store = createStore({ count: 0 }, (set) => ({
   decrement: () => set((state) => ({ count: state.count - 1 })),
 }));
 
+const { increment, decrement } = store.actions;
+
 export const Counter = () => {
   // Use the store
-  const {
-    state: { count },
-    actions: { increment, decrement },
-  } = useStore(store);
+  const { count } = useStore(store);
 
   return (
     <div className="grid grid-cols-3 text-center items-center w-fit">

--- a/apps/demo/src/components/examples/Counter.tsx
+++ b/apps/demo/src/components/examples/Counter.tsx
@@ -3,7 +3,7 @@ import { useStore } from "dharma-react";
 import { Button } from "../ui/button";
 
 // Create the store
-const store = createStore({ count: 0 }, (set) => ({
+const store = createStore({ count: 0 }, ({ set }) => ({
   increment: () => set((state) => ({ count: state.count + 1 })),
   decrement: () => set((state) => ({ count: state.count - 1 })),
 }));

--- a/apps/demo/src/components/examples/Persistent.tsx
+++ b/apps/demo/src/components/examples/Persistent.tsx
@@ -4,19 +4,17 @@ import { ExternalLink } from "lucide-react";
 import { Button } from "../ui/button";
 
 // Create the store
-const store = createPersistentStore(
+const store = createPersistentStore({
   // Provide a unique key to identify the store in storage
-  "count",
-  { count: 0 },
-  ({ set }) => ({
+  key: "count",
+  initialState: { count: 0 },
+  defineActions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
   }),
-  {
-    // storage: sessionStorage,
-    // serializer: superjson,
-  },
-);
+  // storage: sessionStorage,
+  // serializer: superjson,
+});
 
 const { increment, decrement } = store.actions;
 

--- a/apps/demo/src/components/examples/Persistent.tsx
+++ b/apps/demo/src/components/examples/Persistent.tsx
@@ -18,12 +18,11 @@ const store = createPersistentStore(
   },
 );
 
+const { increment, decrement } = store.actions;
+
 export const Persistent = () => {
   // Use the store
-  const {
-    state: { count },
-    actions: { increment, decrement },
-  } = useStore(store);
+  const { count } = useStore(store);
 
   return (
     <div className="container-full w-fit items-center">

--- a/apps/demo/src/components/examples/Persistent.tsx
+++ b/apps/demo/src/components/examples/Persistent.tsx
@@ -8,7 +8,7 @@ const store = createPersistentStore(
   // Provide a unique key to identify the store in storage
   "count",
   { count: 0 },
-  (set) => ({
+  ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
   }),

--- a/apps/demo/src/components/examples/Shared.tsx
+++ b/apps/demo/src/components/examples/Shared.tsx
@@ -36,44 +36,47 @@ const useRenderCount = () => {
   return renderCount.current;
 };
 
-const sharedStore = createStore(initialState, ({ set, get }) => {
-  const setCountState = (countState: StateModifier<CountState>) =>
-    set((state) => ({
-      countState: merge(state.countState, countState),
-    }));
+const sharedStore = createStore({
+  initialState,
+  defineActions: ({ set, get }) => {
+    const setCountState = (countState: StateModifier<CountState>) =>
+      set((state) => ({
+        countState: merge(state.countState, countState),
+      }));
 
-  const setTodoState = (todoState: StateModifier<TodoState>) =>
-    set((state) => ({
-      todoState: merge(state.todoState, todoState),
-    }));
+    const setTodoState = (todoState: StateModifier<TodoState>) =>
+      set((state) => ({
+        todoState: merge(state.todoState, todoState),
+      }));
 
-  return {
-    count: {
-      increment: () => setCountState((state) => ({ count: state.count + 1 })),
-      decrement: () => setCountState((state) => ({ count: state.count - 1 })),
-    },
-    todo: {
-      setInput: (input: string) => setTodoState({ input }),
-      addTodo: () => {
-        if (!get().todoState.input) {
-          return;
-        }
-        setTodoState((state) => ({
-          todos: [...state.todos, { title: state.input, complete: false }],
-          input: "",
-        }));
+    return {
+      count: {
+        increment: () => setCountState((state) => ({ count: state.count + 1 })),
+        decrement: () => setCountState((state) => ({ count: state.count - 1 })),
       },
-      toggleTodo: (index: number) =>
-        setTodoState((state) => ({
-          todos: state.todos.map((todo, i) => {
-            if (index === i) {
-              return { ...todo, complete: !todo.complete };
-            }
-            return todo;
-          }),
-        })),
-    },
-  };
+      todo: {
+        setInput: (input: string) => setTodoState({ input }),
+        addTodo: () => {
+          if (!get().todoState.input) {
+            return;
+          }
+          setTodoState((state) => ({
+            todos: [...state.todos, { title: state.input, complete: false }],
+            input: "",
+          }));
+        },
+        toggleTodo: (index: number) =>
+          setTodoState((state) => ({
+            todos: state.todos.map((todo, i) => {
+              if (index === i) {
+                return { ...todo, complete: !todo.complete };
+              }
+              return todo;
+            }),
+          })),
+      },
+    };
+  },
 });
 
 const { decrement, increment } = sharedStore.actions.count;

--- a/apps/demo/src/components/examples/Shared.tsx
+++ b/apps/demo/src/components/examples/Shared.tsx
@@ -48,11 +48,11 @@ const sharedStore = createStore(initialState, (set, get) => {
     }));
 
   return {
-    countActions: {
+    count: {
       increment: () => setCountState((state) => ({ count: state.count + 1 })),
       decrement: () => setCountState((state) => ({ count: state.count - 1 })),
     },
-    todoActions: {
+    todo: {
       setInput: (input: string) => setTodoState({ input }),
       addTodo: () => {
         if (!get().todoState.input) {
@@ -76,16 +76,14 @@ const sharedStore = createStore(initialState, (set, get) => {
   };
 });
 
+const { decrement, increment } = sharedStore.actions.count;
+const { addTodo, setInput, toggleTodo } = sharedStore.actions.todo;
+
 const useSharedStore = <T = SharedState,>(select?: (state: SharedState) => T) =>
   useStore(sharedStore, select);
 
 const Counter = () => {
-  const {
-    state: { count },
-    actions: {
-      countActions: { increment, decrement },
-    },
-  } = useSharedStore((state) => state.countState);
+  const { count } = useSharedStore((state) => state.countState);
 
   const renderCount = useRenderCount();
 
@@ -105,12 +103,7 @@ const Counter = () => {
 };
 
 const Todo = () => {
-  const {
-    state: { input, todos },
-    actions: {
-      todoActions: { addTodo, setInput, toggleTodo },
-    },
-  } = useSharedStore((state) => state.todoState);
+  const { input, todos } = useSharedStore((state) => state.todoState);
 
   const renderCount = useRenderCount();
 

--- a/apps/demo/src/components/examples/Shared.tsx
+++ b/apps/demo/src/components/examples/Shared.tsx
@@ -36,7 +36,7 @@ const useRenderCount = () => {
   return renderCount.current;
 };
 
-const sharedStore = createStore(initialState, (set, get) => {
+const sharedStore = createStore(initialState, ({ set, get }) => {
   const setCountState = (countState: StateModifier<CountState>) =>
     set((state) => ({
       countState: merge(state.countState, countState),

--- a/apps/demo/src/components/examples/Simple.tsx
+++ b/apps/demo/src/components/examples/Simple.tsx
@@ -2,7 +2,7 @@ import { createStore } from "dharma-core";
 import { useStore } from "dharma-react";
 
 // Create the store
-const store = createStore({ count: 0 }, (set) => ({
+const store = createStore({ count: 0 }, ({ set }) => ({
   increment: () => set((state) => ({ count: state.count + 1 })),
   decrement: () => set((state) => ({ count: state.count - 1 })),
 }));

--- a/apps/demo/src/components/examples/Simple.tsx
+++ b/apps/demo/src/components/examples/Simple.tsx
@@ -7,12 +7,11 @@ const store = createStore({ count: 0 }, (set) => ({
   decrement: () => set((state) => ({ count: state.count - 1 })),
 }));
 
+const { increment, decrement } = store.actions;
+
 export const Counter = () => {
   // Use the store
-  const {
-    state: { count },
-    actions: { increment, decrement },
-  } = useStore(store);
+  const { count } = useStore(store);
 
   return (
     <div>

--- a/apps/demo/src/components/examples/Simple.tsx
+++ b/apps/demo/src/components/examples/Simple.tsx
@@ -2,10 +2,13 @@ import { createStore } from "dharma-core";
 import { useStore } from "dharma-react";
 
 // Create the store
-const store = createStore({ count: 0 }, ({ set }) => ({
-  increment: () => set((state) => ({ count: state.count + 1 })),
-  decrement: () => set((state) => ({ count: state.count - 1 })),
-}));
+const store = createStore({
+  initialState: { count: 0 },
+  defineActions: ({ set }) => ({
+    increment: () => set((state) => ({ count: state.count + 1 })),
+    decrement: () => set((state) => ({ count: state.count - 1 })),
+  }),
+});
 
 const { increment, decrement } = store.actions;
 

--- a/apps/demo/src/components/examples/Todo.tsx
+++ b/apps/demo/src/components/examples/Todo.tsx
@@ -5,44 +5,46 @@ import { Button } from "../ui/button";
 import { Checkbox } from "../ui/checkbox";
 import { Input } from "../ui/input";
 
+// Set up the store
+
 interface TodoState {
   input: string;
   todos: { title: string; complete: boolean }[];
 }
 
-const store = createStore(
-  {
-    input: "",
-    todos: [],
-  } as TodoState,
-  (set, get) => ({
-    setInput: (input: string) => set({ input }),
-    addTodo: () => {
-      if (!get().input) {
-        return;
-      }
-      set((state) => ({
-        todos: [...state.todos, { title: state.input, complete: false }],
-        input: "",
-      }));
-    },
-    toggleTodo: (index: number) =>
-      set((state) => ({
-        todos: state.todos.map((todo, i) => {
-          if (index === i) {
-            return { ...todo, complete: !todo.complete };
-          }
-          return todo;
-        }),
-      })),
-  }),
-);
+const initialState: TodoState = {
+  input: "",
+  todos: [],
+};
+
+const store = createStore(initialState, (set, get) => ({
+  setInput: (input: string) => set({ input }),
+  addTodo: () => {
+    if (!get().input) {
+      return;
+    }
+    set((state) => ({
+      todos: [...state.todos, { title: state.input, complete: false }],
+      input: "",
+    }));
+  },
+  toggleTodo: (index: number) =>
+    set((state) => ({
+      todos: state.todos.map((todo, i) => {
+        if (index === i) {
+          return { ...todo, complete: !todo.complete };
+        }
+        return todo;
+      }),
+    })),
+}));
+
+const { setInput, addTodo, toggleTodo } = store.actions;
+
+// Bind the store to the component
 
 export const Todo = () => {
-  const {
-    state: { input, todos },
-    actions: { addTodo, setInput, toggleTodo },
-  } = useStore(store);
+  const { input, todos } = useStore(store);
 
   return (
     <div className="flex flex-col gap-4 container-full w-fit">

--- a/apps/demo/src/components/examples/Todo.tsx
+++ b/apps/demo/src/components/examples/Todo.tsx
@@ -17,27 +17,30 @@ const initialState: TodoState = {
   todos: [],
 };
 
-const store = createStore(initialState, ({ set, get }) => ({
-  setInput: (input: string) => set({ input }),
-  addTodo: () => {
-    if (!get().input) {
-      return;
-    }
-    set((state) => ({
-      todos: [...state.todos, { title: state.input, complete: false }],
-      input: "",
-    }));
-  },
-  toggleTodo: (index: number) =>
-    set((state) => ({
-      todos: state.todos.map((todo, i) => {
-        if (index === i) {
-          return { ...todo, complete: !todo.complete };
-        }
-        return todo;
-      }),
-    })),
-}));
+const store = createStore({
+  initialState,
+  defineActions: ({ set, get }) => ({
+    setInput: (input: string) => set({ input }),
+    addTodo: () => {
+      if (!get().input) {
+        return;
+      }
+      set((state) => ({
+        todos: [...state.todos, { title: state.input, complete: false }],
+        input: "",
+      }));
+    },
+    toggleTodo: (index: number) =>
+      set((state) => ({
+        todos: state.todos.map((todo, i) => {
+          if (index === i) {
+            return { ...todo, complete: !todo.complete };
+          }
+          return todo;
+        }),
+      })),
+  }),
+});
 
 const { setInput, addTodo, toggleTodo } = store.actions;
 

--- a/apps/demo/src/components/examples/Todo.tsx
+++ b/apps/demo/src/components/examples/Todo.tsx
@@ -17,7 +17,7 @@ const initialState: TodoState = {
   todos: [],
 };
 
-const store = createStore(initialState, (set, get) => ({
+const store = createStore(initialState, ({ set, get }) => ({
   setInput: (input: string) => set({ input }),
   addTodo: () => {
     if (!get().input) {

--- a/apps/demo/src/pages/vanilla.astro
+++ b/apps/demo/src/pages/vanilla.astro
@@ -14,10 +14,13 @@ import Layout from '../layouts/Layout.astro';
 <script>
   import { createStore } from 'dharma-core';
 
-  const store = createStore({ count: 0 }, (set) => ({
-    increment: () => set((state) => ({ count: state.count + 1 })),
-    decrement: () => set((state) => ({ count: state.count - 1 })),
-  }));
+  const store = createStore({
+    initialState: { count: 0 },
+    defineActions: ({ set }) => ({
+      increment: () => set((state) => ({ count: state.count + 1 })),
+      decrement: () => set((state) => ({ count: state.count - 1 })),
+    }),
+  });
 
   const count = document.getElementById('count')!;
   const decrementBtn = document.getElementById('decrement-btn')!;

--- a/packages/dharma-core/src/lib/createPersistentStore.node.test.ts
+++ b/packages/dharma-core/src/lib/createPersistentStore.node.test.ts
@@ -4,18 +4,23 @@ import { describe, expect, it, vi } from "vitest";
 import { createPersistentStore } from "./createPersistentStore";
 
 describe("createPersistentStore", () => {
-  const actions = vi.fn();
+  const base = {
+    key: "test",
+    initialState: { count: 0 },
+    defineActions: vi.fn(),
+  };
+
   it("should not throw in a node environment", () => {
+    expect(() => createPersistentStore(base)).not.toThrow();
     expect(() =>
-      createPersistentStore("test", { count: 0 }, actions),
-    ).not.toThrow();
-    expect(() =>
-      createPersistentStore("test", { count: 0 }, actions, {
+      createPersistentStore({
+        ...base,
         storage: "local",
       }),
     ).not.toThrow();
     expect(() =>
-      createPersistentStore("test", { count: 0 }, actions, {
+      createPersistentStore({
+        ...base,
         storage: "session",
       }),
     ).not.toThrow();

--- a/packages/dharma-core/src/lib/createPersistentStore.test.ts
+++ b/packages/dharma-core/src/lib/createPersistentStore.test.ts
@@ -9,7 +9,7 @@ describe("createPersistentStore", () => {
   const key = "test";
   const initialState = { count: 0 };
   const listener = vi.fn();
-  const actions = vi.fn();
+  const defineActions = vi.fn();
   const initKey = `init_${key}`;
   const storeKey = `store_${key}`;
 
@@ -19,12 +19,12 @@ describe("createPersistentStore", () => {
   });
 
   it("should initialize with the given initial state", () => {
-    const store = createPersistentStore(key, initialState, actions);
+    const store = createPersistentStore({ key, initialState, defineActions });
     expect(store.get()).toEqual(initialState);
   });
 
   it("should persist state changes to localStorage", () => {
-    const store = createPersistentStore(key, initialState, actions);
+    const store = createPersistentStore({ key, initialState, defineActions });
     store.subscribe(listener);
     store.set({ count: 1 });
     const storedState = localStorage.getItem(storeKey);
@@ -34,7 +34,7 @@ describe("createPersistentStore", () => {
   it("should load state from localStorage if available", () => {
     localStorage.setItem(initKey, JSON.stringify({ count: 0 }));
     localStorage.setItem(storeKey, JSON.stringify({ count: 1 }));
-    const store = createPersistentStore(key, initialState, actions);
+    const store = createPersistentStore({ key, initialState, defineActions });
     expect(store.get()).toEqual({ count: 0 });
     store.subscribe(listener);
     expect(store.get()).toEqual({ count: 1 });
@@ -43,7 +43,10 @@ describe("createPersistentStore", () => {
   it("should load state from sessionStorage if available", () => {
     sessionStorage.setItem(initKey, JSON.stringify({ count: 0 }));
     sessionStorage.setItem(storeKey, JSON.stringify({ count: 2 }));
-    const store = createPersistentStore(key, initialState, actions, {
+    const store = createPersistentStore({
+      key,
+      initialState,
+      defineActions,
       storage: sessionStorage,
     });
     store.subscribe(listener);
@@ -51,7 +54,7 @@ describe("createPersistentStore", () => {
   });
 
   it("should update state when window gains focus", () => {
-    const store = createPersistentStore(key, initialState, actions);
+    const store = createPersistentStore({ key, initialState, defineActions });
     store.subscribe(listener);
     store.set({ count: 1 });
     localStorage.setItem(storeKey, JSON.stringify({ count: 2 }));
@@ -64,7 +67,10 @@ describe("createPersistentStore", () => {
       stringify: vi.fn(),
       parse: vi.fn(),
     };
-    const store = createPersistentStore(key, initialState, actions, {
+    const store = createPersistentStore({
+      key,
+      initialState,
+      defineActions,
       serializer: customSerializer,
     });
     store.set({ count: 1 });
@@ -77,7 +83,10 @@ describe("createPersistentStore", () => {
       setItem: vi.fn(),
       removeItem: vi.fn(),
     };
-    const store = createPersistentStore(key, initialState, actions, {
+    const store = createPersistentStore({
+      key,
+      initialState,
+      defineActions,
       storage: customStorage,
     });
     store.set({ count: 1 });

--- a/packages/dharma-core/src/lib/createPersistentStore.ts
+++ b/packages/dharma-core/src/lib/createPersistentStore.ts
@@ -68,7 +68,6 @@ export type PersistentStoreConfiguration<
  *   },
  * );
  * ```
- * @group Core
  */
 export const createPersistentStore = <
   TState extends object,

--- a/packages/dharma-core/src/lib/createPersistentStore.ts
+++ b/packages/dharma-core/src/lib/createPersistentStore.ts
@@ -39,7 +39,7 @@ export type PersistentStoreOptions<TState extends object> =
  * ```ts
  * import { createPersistentStore } from "dharma-core";
  *
- * const store = createPersistentStore("count", { count: 0 }, (set) => ({
+ * const store = createPersistentStore("count", { count: 0 }, ({ set }) => ({
  *   increment: () => set((state) => ({ count: state.count + 1 })),
  *   decrement: () => set((state) => ({ count: state.count - 1 })),
  *   reset: () => set({ count: 0 }),
@@ -54,7 +54,7 @@ export type PersistentStoreOptions<TState extends object> =
  * const store = createPersistentStore(
  *   "count",
  *   { count: 0 },
- *   (set) => ({
+ *   ({ set }) => ({
  *     increment: () => set((state) => ({ count: state.count + 1 })),
  *     decrement: () => set((state) => ({ count: state.count - 1 })),
  *     reset: () => set({ count: 0 }),
@@ -119,17 +119,17 @@ export const createPersistentStore = <
   };
 
   const store = createStore(initialState, defineActions, {
-    onAttach: (...args) => {
-      onAttach?.(...args);
+    onAttach: (ctx) => {
+      onAttach?.(ctx);
       updateState();
       window.addEventListener("focus", updateState);
     },
-    onDetach: (...args) => {
-      onDetach?.(...args);
+    onDetach: (ctx) => {
+      onDetach?.(ctx);
       window.removeEventListener("focus", updateState);
     },
-    onChange: (state, ...args) => {
-      onChange?.(state, ...args);
+    onChange: ({ state, ...ctx }) => {
+      onChange?.({ state, ...ctx });
       updateSnapshot(state);
     },
     ...options,

--- a/packages/dharma-core/src/lib/createStore.test.ts
+++ b/packages/dharma-core/src/lib/createStore.test.ts
@@ -38,7 +38,7 @@ describe("createStore", () => {
 
   it("should create actions if provided", () => {
     const initialState = { count: 0 };
-    const store = createStore(initialState, (set, get) => ({
+    const store = createStore(initialState, ({ set, get }) => ({
       increment: () => set((state) => ({ count: state.count + 1 })),
       decrement: () => set((state) => ({ count: state.count - 1 })),
       getCount: () => get().count,
@@ -52,7 +52,7 @@ describe("createStore", () => {
   it("should call onChange if provided", () => {
     const initialState = { count: 0, other: "foo" };
     const store = createStore(initialState, actions, {
-      onChange: (state, set) => set({ other: state.other + "bar" }),
+      onChange: ({ state, set }) => set({ other: state.other + "bar" }),
     });
     store.set({ count: 1 });
     expect(store.get()).toEqual({ count: 1, other: "foobar" });
@@ -61,7 +61,7 @@ describe("createStore", () => {
   it("should call onAttach on first subscribe", () => {
     const initialState = { count: 0 };
     const store = createStore(initialState, actions, {
-      onAttach: (state, set) => set({ count: state.count + 1 }),
+      onAttach: ({ state, set }) => set({ count: state.count + 1 }),
     });
     const listener = vi.fn();
     store.subscribe(listener);
@@ -71,7 +71,7 @@ describe("createStore", () => {
   it("should call onDetach on last unsubscribe", () => {
     const initialState = { count: 0 };
     const store = createStore(initialState, actions, {
-      onDetach: (state, set) => set({ count: state.count + 1 }),
+      onDetach: ({ state, set }) => set({ count: state.count + 1 }),
     });
     const listener = vi.fn();
     const unsubscribe = store.subscribe(listener);
@@ -82,7 +82,7 @@ describe("createStore", () => {
   it("should call onLoad on store creation", () => {
     const initialState = { count: 0 };
     const store = createStore(initialState, actions, {
-      onLoad: (state, set) => set({ count: state.count + 1 }),
+      onLoad: ({ state, set }) => set({ count: state.count + 1 }),
     });
     expect(store.get().count).toBe(1);
   });

--- a/packages/dharma-core/src/lib/createStore.test.ts
+++ b/packages/dharma-core/src/lib/createStore.test.ts
@@ -2,17 +2,17 @@ import { describe, expect, it, vi } from "vitest";
 import { createStore } from "./createStore";
 
 describe("createStore", () => {
-  const actions = vi.fn();
+  const defineActions = vi.fn();
 
   it("should initialize with the given state", () => {
     const initialState = { count: 0 };
-    const store = createStore(initialState, actions);
+    const store = createStore({ initialState, defineActions });
     expect(store.get()).toEqual(initialState);
   });
 
   it("should update the state using set and reset", () => {
     const initialState = { count: 0 };
-    const store = createStore(initialState, actions);
+    const store = createStore({ initialState, defineActions });
     store.set({ count: 1 });
     expect(store.get().count).toBe(1);
     store.reset();
@@ -21,7 +21,7 @@ describe("createStore", () => {
 
   it("should notify subscribers on state change", () => {
     const initialState = { count: 0 };
-    const store = createStore(initialState, actions);
+    const store = createStore({ initialState, defineActions });
     const listener = vi.fn();
     store.subscribe(listener);
     store.set({ count: 1 });
@@ -30,7 +30,7 @@ describe("createStore", () => {
 
   it("should unsubscribe listeners correctly", () => {
     const initialState = { count: 0 };
-    const store = createStore(initialState, actions);
+    const store = createStore({ initialState, defineActions });
     const listener = vi.fn();
     const unsubscribe = store.subscribe(listener);
     unsubscribe();
@@ -39,12 +39,14 @@ describe("createStore", () => {
   });
 
   it("should create actions if provided", () => {
-    const initialState = { count: 0 };
-    const store = createStore(initialState, ({ set, get, reset }) => ({
-      increment: () => set((state) => ({ count: state.count + 1 })),
-      getCount: () => get().count,
-      resetCount: () => reset(),
-    }));
+    const store = createStore({
+      initialState: { count: 0 },
+      defineActions: ({ set, get, reset }) => ({
+        increment: () => set((state) => ({ count: state.count + 1 })),
+        getCount: () => get().count,
+        resetCount: () => reset(),
+      }),
+    });
     store.actions.increment();
     expect(store.actions.getCount()).toBe(1);
     store.actions.resetCount();
@@ -53,7 +55,9 @@ describe("createStore", () => {
 
   it("should call onChange if provided", () => {
     const initialState = { count: 0, other: "foo" };
-    const store = createStore(initialState, actions, {
+    const store = createStore({
+      initialState,
+      defineActions,
       onChange: ({ state, set }) => set({ other: state.other + "bar" }),
     });
     store.set({ count: 1 });
@@ -62,7 +66,9 @@ describe("createStore", () => {
 
   it("should call onAttach on first subscribe", () => {
     const initialState = { count: 0 };
-    const store = createStore(initialState, actions, {
+    const store = createStore({
+      initialState,
+      defineActions,
       onAttach: ({ state, set }) => set({ count: state.count + 1 }),
     });
     const listener = vi.fn();
@@ -72,7 +78,9 @@ describe("createStore", () => {
 
   it("should call onDetach on last unsubscribe", () => {
     const initialState = { count: 0 };
-    const store = createStore(initialState, actions, {
+    const store = createStore({
+      initialState,
+      defineActions,
       onDetach: ({ state, set }) => set({ count: state.count + 1 }),
     });
     const listener = vi.fn();
@@ -83,7 +91,9 @@ describe("createStore", () => {
 
   it("should call onLoad on store creation", () => {
     const initialState = { count: 0 };
-    const store = createStore(initialState, actions, {
+    const store = createStore({
+      initialState,
+      defineActions,
       onLoad: ({ state, set }) => set({ count: state.count + 1 }),
     });
     expect(store.get().count).toBe(1);

--- a/packages/dharma-core/src/lib/createStore.test.ts
+++ b/packages/dharma-core/src/lib/createStore.test.ts
@@ -10,11 +10,13 @@ describe("createStore", () => {
     expect(store.get()).toEqual(initialState);
   });
 
-  it("should update the state using set", () => {
+  it("should update the state using set and reset", () => {
     const initialState = { count: 0 };
     const store = createStore(initialState, actions);
     store.set({ count: 1 });
     expect(store.get().count).toBe(1);
+    store.reset();
+    expect(store.get().count).toBe(0);
   });
 
   it("should notify subscribers on state change", () => {
@@ -38,14 +40,14 @@ describe("createStore", () => {
 
   it("should create actions if provided", () => {
     const initialState = { count: 0 };
-    const store = createStore(initialState, ({ set, get }) => ({
+    const store = createStore(initialState, ({ set, get, reset }) => ({
       increment: () => set((state) => ({ count: state.count + 1 })),
-      decrement: () => set((state) => ({ count: state.count - 1 })),
       getCount: () => get().count,
+      resetCount: () => reset(),
     }));
     store.actions.increment();
     expect(store.actions.getCount()).toBe(1);
-    store.actions.decrement();
+    store.actions.resetCount();
     expect(store.actions.getCount()).toBe(0);
   });
 

--- a/packages/dharma-core/src/lib/createStore.ts
+++ b/packages/dharma-core/src/lib/createStore.ts
@@ -126,11 +126,11 @@ export const createStore = <
   };
 
   const subscribe = (listener: Listener<TState>) => {
-    listener(state);
     if (listeners.size === 0) {
       onAttach?.({ state, set, reset });
     }
 
+    listener(state);
     listeners.add(listener);
 
     return () => {

--- a/packages/dharma-core/src/lib/createStore.ts
+++ b/packages/dharma-core/src/lib/createStore.ts
@@ -86,7 +86,6 @@ export type StoreConfiguration<
  *   }),
  * });
  * ```
- * @group Core
  */
 export const createStore = <
   TState extends object,

--- a/packages/dharma-core/src/lib/createStore.ts
+++ b/packages/dharma-core/src/lib/createStore.ts
@@ -7,6 +7,8 @@ export type Store<TState extends object, TActions extends object> = {
   get: () => TState;
   /** Sets the state of the store. */
   set: (stateModifier: StateModifier<TState>) => TState;
+  /** Resets the state of the store to its initial value. */
+  reset: () => TState;
   /** Actions that can modify the state of the store. */
   actions: TActions;
   /** Subscribes to changes in the state of the store. Returns an unsubscribe function. */
@@ -33,6 +35,7 @@ export type StateModifier<TState extends object> =
 export type StateFunctions<TState extends object> = {
   set: (stateModifier: StateModifier<TState>) => TState;
   get: () => TState;
+  reset: () => TState;
 };
 
 export type DefineActions<TState extends object, TActions> = (
@@ -117,8 +120,14 @@ export const createStore = <
     };
   };
 
+  const reset = () => {
+    state = initialState;
+    dispatch();
+    return state;
+  };
+
   const actions = defineActions
-    ? defineActions({ set, get })
+    ? defineActions({ set, get, reset })
     : ({} as TActions);
 
   onLoad?.({ state, set });
@@ -126,6 +135,7 @@ export const createStore = <
   return {
     get,
     set,
+    reset,
     subscribe,
     actions,
   };

--- a/packages/dharma-core/src/lib/merge.ts
+++ b/packages/dharma-core/src/lib/merge.ts
@@ -34,7 +34,6 @@ import { StateModifier } from "./createStore";
  *   },
  * });
  * ```
- * @group Utilities
  */
 export const merge = <T extends object>(
   currentState: T,

--- a/packages/dharma-core/src/lib/merge.ts
+++ b/packages/dharma-core/src/lib/merge.ts
@@ -12,14 +12,14 @@ import { StateModifier } from "./createStore";
  * ```ts
  * import { createStore, merge, StateModifier } from "dharma-core";
  *
- * const store = createStore(
- *   {
+ * const store = createStore({
+ *   initialState: {
  *     counter: {
  *       count: 0,
  *     },
  *     // ...
  *   },
- *   (set) => {
+ *   defineActions: ({ set }) => {
  *     const setCounter = (counter: StateModifier<{ count: number }>) =>
  *       set((state) => ({
  *         counter: merge(state.counter, counter),
@@ -32,7 +32,7 @@ import { StateModifier } from "./createStore";
  *       // ...
  *     };
  *   },
- * );
+ * });
  * ```
  * @group Utilities
  */

--- a/packages/dharma-react/src/lib/createStoreContext.test.ts
+++ b/packages/dharma-react/src/lib/createStoreContext.test.ts
@@ -5,7 +5,7 @@ import { createStoreContext } from "./createStoreContext";
 describe("createStoreContext", () => {
   it("should create a store context with an instantiation function", () => {
     const instantiate = (initialCount: number) =>
-      createStore({ count: initialCount }, (set) => ({
+      createStore({ count: initialCount }, ({ set }) => ({
         increment: () => set((state) => ({ count: state.count + 1 })),
         decrement: () => set((state) => ({ count: state.count - 1 })),
         reset: () => set({ count: 0 }),
@@ -19,7 +19,7 @@ describe("createStoreContext", () => {
 
   it("should instantiate a new store with the given arguments", () => {
     const instantiate = (initialCount: number) =>
-      createStore({ count: initialCount }, (set) => ({
+      createStore({ count: initialCount }, ({ set }) => ({
         increment: () => set((state) => ({ count: state.count + 1 })),
         decrement: () => set((state) => ({ count: state.count - 1 })),
         reset: () => set({ count: 0 }),

--- a/packages/dharma-react/src/lib/createStoreContext.test.ts
+++ b/packages/dharma-react/src/lib/createStoreContext.test.ts
@@ -4,28 +4,34 @@ import { createStoreContext } from "./createStoreContext";
 
 describe("createStoreContext", () => {
   it("should create a store context with an instantiation function", () => {
-    const instantiate = (initialCount: number) =>
-      createStore({ count: initialCount }, ({ set }) => ({
-        increment: () => set((state) => ({ count: state.count + 1 })),
-        decrement: () => set((state) => ({ count: state.count - 1 })),
-        reset: () => set({ count: 0 }),
-      }));
+    const createCountStore = (initialCount: number) =>
+      createStore({
+        initialState: { count: initialCount },
+        defineActions: ({ set }) => ({
+          increment: () => set((state) => ({ count: state.count + 1 })),
+          decrement: () => set((state) => ({ count: state.count - 1 })),
+          reset: () => set({ count: 0 }),
+        }),
+      });
 
-    const StoreContext = createStoreContext(instantiate);
+    const StoreContext = createStoreContext(createCountStore);
 
     expect(StoreContext).toHaveProperty("createStore");
     expect(typeof StoreContext.createStore).toBe("function");
   });
 
   it("should instantiate a new store with the given arguments", () => {
-    const instantiate = (initialCount: number) =>
-      createStore({ count: initialCount }, ({ set }) => ({
-        increment: () => set((state) => ({ count: state.count + 1 })),
-        decrement: () => set((state) => ({ count: state.count - 1 })),
-        reset: () => set({ count: 0 }),
-      }));
+    const createCountStore = (initialCount: number) =>
+      createStore({
+        initialState: { count: initialCount },
+        defineActions: ({ set }) => ({
+          increment: () => set((state) => ({ count: state.count + 1 })),
+          decrement: () => set((state) => ({ count: state.count - 1 })),
+          reset: () => set({ count: 0 }),
+        }),
+      });
 
-    const StoreContext = createStoreContext(instantiate);
+    const StoreContext = createStoreContext(createCountStore);
     const store = StoreContext.createStore(5);
 
     expect(store.get()).toEqual({ count: 5 });

--- a/packages/dharma-react/src/lib/createStoreContext.ts
+++ b/packages/dharma-react/src/lib/createStoreContext.ts
@@ -24,7 +24,7 @@ export type StoreContext<
  * import { useMemo } from "react";
  *
  * const StoreContext = createStoreContext((initialCount: number) =>
- *   createStore({ count: initialCount }, (set) => ({
+ *   createStore({ count: initialCount }, ({ set }) => ({
  *     increment: () => set((state) => ({ count: state.count + 1 })),
  *     decrement: () => set((state) => ({ count: state.count - 1 })),
  *     reset: () => set({ count: 0 }),

--- a/packages/dharma-react/src/lib/createStoreContext.ts
+++ b/packages/dharma-react/src/lib/createStoreContext.ts
@@ -48,7 +48,6 @@ export type StoreContext<
  *   );
  * }
  * ```
- * @group Utilities
  */
 export const createStoreContext = <
   TArgs extends unknown[],

--- a/packages/dharma-react/src/lib/useStore.test.tsx
+++ b/packages/dharma-react/src/lib/useStore.test.tsx
@@ -12,11 +12,14 @@ const useRenderCount = () => {
 };
 
 describe("useStore", () => {
-  const store = createStore({ count: 0 }, ({ set }) => ({
-    increment: () => set((state) => ({ count: state.count + 1 })),
-    decrement: () => set((state) => ({ count: state.count - 1 })),
-    reset: () => set({ count: 0 }),
-  }));
+  const store = createStore({
+    initialState: { count: 0 },
+    defineActions: ({ set }) => ({
+      increment: () => set((state) => ({ count: state.count + 1 })),
+      decrement: () => set((state) => ({ count: state.count - 1 })),
+      reset: () => set({ count: 0 }),
+    }),
+  });
 
   const { increment, reset } = store.actions;
 
@@ -41,10 +44,13 @@ describe("useStore", () => {
   });
 
   it("should return the selected state and only re-render when the selected state changes", async () => {
-    const testStore = createStore({ count: 0, foo: 0 }, ({ set }) => ({
-      increaseCount: () => set((state) => ({ count: state.count + 1 })),
-      increaseFoo: () => set((state) => ({ foo: state.foo + 1 })),
-    }));
+    const testStore = createStore({
+      initialState: { count: 0, foo: 0 },
+      defineActions: ({ set }) => ({
+        increaseCount: () => set((state) => ({ count: state.count + 1 })),
+        increaseFoo: () => set((state) => ({ foo: state.foo + 1 })),
+      }),
+    });
 
     const { increaseCount, increaseFoo } = testStore.actions;
 

--- a/packages/dharma-react/src/lib/useStore.test.tsx
+++ b/packages/dharma-react/src/lib/useStore.test.tsx
@@ -18,31 +18,26 @@ describe("useStore", () => {
     reset: () => set({ count: 0 }),
   }));
 
+  const { increment, reset } = store.actions;
+
   afterEach(() => {
-    store.actions.reset();
+    reset();
   });
 
   it("should return the initial state and actions", () => {
     const { result } = renderHook(() => useStore(store));
 
-    expect(result.current).toStrictEqual({
-      state: { count: 0 },
-      actions: {
-        increment: expect.any(Function),
-        decrement: expect.any(Function),
-        reset: expect.any(Function),
-      },
-    });
+    expect(result.current).toStrictEqual({ count: 0 });
   });
 
   it("should call the action functions", () => {
     const { result } = renderHook(() => useStore(store));
 
     act(() => {
-      result.current.actions.increment();
+      increment();
     });
 
-    expect(result.current.state).toStrictEqual({ count: 1 });
+    expect(result.current).toStrictEqual({ count: 1 });
   });
 
   it("should return the selected state and only re-render when the selected state changes", async () => {
@@ -51,11 +46,10 @@ describe("useStore", () => {
       increaseFoo: () => set((state) => ({ foo: state.foo + 1 })),
     }));
 
+    const { increaseCount, increaseFoo } = testStore.actions;
+
     const Component = () => {
-      const {
-        state: count,
-        actions: { increaseCount, increaseFoo },
-      } = useStore(testStore, (state) => state.count);
+      const count = useStore(testStore, (state) => state.count);
       const renderCount = useRenderCount();
 
       return (

--- a/packages/dharma-react/src/lib/useStore.test.tsx
+++ b/packages/dharma-react/src/lib/useStore.test.tsx
@@ -12,7 +12,7 @@ const useRenderCount = () => {
 };
 
 describe("useStore", () => {
-  const store = createStore({ count: 0 }, (set) => ({
+  const store = createStore({ count: 0 }, ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
     reset: () => set({ count: 0 }),
@@ -41,7 +41,7 @@ describe("useStore", () => {
   });
 
   it("should return the selected state and only re-render when the selected state changes", async () => {
-    const testStore = createStore({ count: 0, foo: 0 }, (set) => ({
+    const testStore = createStore({ count: 0, foo: 0 }, ({ set }) => ({
       increaseCount: () => set((state) => ({ count: state.count + 1 })),
       increaseFoo: () => set((state) => ({ foo: state.foo + 1 })),
     }));

--- a/packages/dharma-react/src/lib/useStore.ts
+++ b/packages/dharma-react/src/lib/useStore.ts
@@ -39,8 +39,6 @@ import { deeplyEquals } from "./deeplyEquals";
  * If the `select` function is provided, an equality check is performed. This has some caveats:
  * - For optimal performance, return a direct reference to the state. (e.g. `state.count`)
  * - If you return an object literal, it should only contain direct references to the state. (e.g. `{ count: state.count }`)
- *
- * @group Hooks
  */
 export const useStore = <
   TState extends object,

--- a/packages/dharma-react/src/lib/useStoreContext.test.tsx
+++ b/packages/dharma-react/src/lib/useStoreContext.test.tsx
@@ -38,6 +38,7 @@ describe("useStoreContext", () => {
     const { result } = renderUseStoreContext();
     expect(result.current).toStrictEqual({
       state: { count: 0 },
+      set: expect.any(Function),
       actions: {
         increment: expect.any(Function),
         decrement: expect.any(Function),

--- a/packages/dharma-react/src/lib/useStoreContext.test.tsx
+++ b/packages/dharma-react/src/lib/useStoreContext.test.tsx
@@ -7,7 +7,7 @@ import { useStoreContext } from "./useStoreContext";
 
 describe("useStoreContext", () => {
   const StoreContext = createStoreContext((initialCount: number) =>
-    createStore({ count: initialCount }, (set) => ({
+    createStore({ count: initialCount }, ({ set }) => ({
       increment: () => set((state) => ({ count: state.count + 1 })),
       decrement: () => set((state) => ({ count: state.count - 1 })),
       reset: () => set({ count: 0 }),

--- a/packages/dharma-react/src/lib/useStoreContext.test.tsx
+++ b/packages/dharma-react/src/lib/useStoreContext.test.tsx
@@ -7,11 +7,14 @@ import { useStoreContext } from "./useStoreContext";
 
 describe("useStoreContext", () => {
   const StoreContext = createStoreContext((initialCount: number) =>
-    createStore({ count: initialCount }, ({ set }) => ({
-      increment: () => set((state) => ({ count: state.count + 1 })),
-      decrement: () => set((state) => ({ count: state.count - 1 })),
-      reset: () => set({ count: 0 }),
-    })),
+    createStore({
+      initialState: { count: initialCount },
+      defineActions: ({ set }) => ({
+        increment: () => set((state) => ({ count: state.count + 1 })),
+        decrement: () => set((state) => ({ count: state.count - 1 })),
+        reset: () => set({ count: 0 }),
+      }),
+    }),
   );
 
   const renderUseStoreContext = <T,>(

--- a/packages/dharma-react/src/lib/useStoreContext.ts
+++ b/packages/dharma-react/src/lib/useStoreContext.ts
@@ -53,8 +53,6 @@ export type BoundStore<
  * If the `select` function is provided, an equality check is performed. This has some caveats:
  * - For optimal performance, return a direct reference to the state. (e.g. `state.count`)
  * - If you return an object literal, it should only contain direct references to the state. (e.g. `{ count: state.count }`)
- *
- * @group Hooks
  */
 export const useStoreContext = <
   TArgs extends unknown[],

--- a/packages/dharma-react/src/lib/useStoreContext.ts
+++ b/packages/dharma-react/src/lib/useStoreContext.ts
@@ -1,11 +1,22 @@
+import { StateModifier } from "dharma-core";
 import { useContext } from "react";
 import { StoreContext } from "./createStoreContext";
-import { BoundStore, useStore } from "./useStore";
+import { useStore } from "./useStore";
+
+export type BoundStore<
+  TState extends object,
+  TActions extends object,
+  TSelection = TState,
+> = {
+  state: TSelection;
+  actions: TActions;
+  set: (stateModifier: StateModifier<TState>) => TState;
+};
 
 /**
  * A hook used to access a store context created with `createStoreContext`.
  *
- * @param {StoreContext<TArgs, TState, TActions>} storeContext - The context of the store.
+ * @param {StoreContext<TArgs, TState, TActions>} StoreContext - The context of the store.
  * @param {(state: TState) => TSelection} [select] - A function to select a subset of the state. Can prevent unnecessary re-renders.
  * @returns {BoundStore<TState, TActions, TSelection>} The store instance.
  *
@@ -35,8 +46,8 @@ import { BoundStore, useStore } from "./useStore";
  * With a select function:
  * ```tsx
  * const {
- *   state: { count },
- * } = useStoreContext(GlobalStoreContext, (state) => state.counter);
+ *   state: count,
+ * } = useStoreContext(StoreContext, (state) => state.count);
  * ```
  * @remarks
  * If the `select` function is provided, an equality check is performed. This has some caveats:
@@ -51,14 +62,15 @@ export const useStoreContext = <
   TActions extends object,
   TSelection = TState,
 >(
-  storeContext: StoreContext<TArgs, TState, TActions>,
+  StoreContext: StoreContext<TArgs, TState, TActions>,
   select?: (state: TState) => TSelection,
 ): BoundStore<TState, TActions, TSelection> => {
-  const store = useContext(storeContext);
+  const store = useContext(StoreContext);
   if (!store) {
     throw new Error(
       "Store context not found. Make sure you are using the store context within a provider.",
     );
   }
-  return useStore(store, select);
+  const state = useStore(store, select);
+  return { state, actions: store.actions, set: store.set };
 };


### PR DESCRIPTION
## dharma-core
- Added reset function to store event handlers
- Consolidated createStore arguments to one configuration object
- onAttach is now invoked before the first listener subscribes
- Event handler and defineActions arguments consolidated to an object
## dharma-react
- useStore no longer returns store actions
- jsdoc update