### PR TITLE
chore: Removed dharma-core peer dependency from dharma-react

### DIFF
--- a/packages/dharma-react/package.json
+++ b/packages/dharma-react/package.json
@@ -46,7 +46,6 @@
     "react": "^19.1.1"
   },
   "peerDependencies": {
-    "dharma-core": "^0.3.0",
     "react": "^19.1.1"
   }
 }


### PR DESCRIPTION
Temporary workaround to prevent changesets from bumping the major version of dharma-react whenever dharma-core is bumped. 