### PR TITLE
feat: persistent

### DIFF
--- a/.changeset/olive-bats-juggle.md
+++ b/.changeset/olive-bats-juggle.md
@@ -1,0 +1,5 @@
+---
+"dharma-core": minor
+---
+
+createPersistentStorage: The storage option now only supports storage objects (previously "local" and "session")

--- a/.changeset/twenty-schools-read.md
+++ b/.changeset/twenty-schools-read.md
@@ -1,0 +1,5 @@
+---
+"dharma-core": patch
+---
+
+createPersistentStorage now works in non-browser environments if a storage is provided

--- a/.changeset/whole-numbers-hope.md
+++ b/.changeset/whole-numbers-hope.md
@@ -1,0 +1,6 @@
+---
+"dharma-react": patch
+"dharma-core": patch
+---
+
+jsdoc updates

--- a/packages/dharma-core/src/lib/createPersistentStore.node.test.ts
+++ b/packages/dharma-core/src/lib/createPersistentStore.node.test.ts
@@ -12,17 +12,5 @@ describe("createPersistentStore", () => {
 
   it("should not throw in a node environment", () => {
     expect(() => createPersistentStore(base)).not.toThrow();
-    expect(() =>
-      createPersistentStore({
-        ...base,
-        storage: "local",
-      }),
-    ).not.toThrow();
-    expect(() =>
-      createPersistentStore({
-        ...base,
-        storage: "session",
-      }),
-    ).not.toThrow();
   });
 });

--- a/packages/dharma-core/src/lib/createPersistentStore.node.test.ts
+++ b/packages/dharma-core/src/lib/createPersistentStore.node.test.ts
@@ -1,16 +1,38 @@
 // @vitest-environment node
 
 import { describe, expect, it, vi } from "vitest";
-import { createPersistentStore } from "./createPersistentStore";
+import { createPersistentStore, StorageAPI } from "./createPersistentStore";
 
 describe("createPersistentStore", () => {
-  const base = {
+  const baseConfig = {
     key: "test",
     initialState: { count: 0 },
     defineActions: vi.fn(),
   };
 
   it("should not throw in a node environment", () => {
-    expect(() => createPersistentStore(base)).not.toThrow();
+    expect(() => createPersistentStore(baseConfig)).not.toThrow();
+  });
+
+  it("should use the provided storage", () => {
+    const storage = new CustomStorage();
+    const store = createPersistentStore({ ...baseConfig, storage });
+    expect(storage.getItem("init_test")).toBe(JSON.stringify({ count: 0 }));
+    store.set({ count: 1 });
+    expect(storage.getItem("test")).toBe(JSON.stringify({ count: 1 }));
   });
 });
+
+class CustomStorage implements StorageAPI {
+  private store: Record<string, string> = {};
+
+  getItem(key: string): string | null {
+    return this.store[key] || null;
+  }
+  setItem(key: string, value: string): void {
+    this.store[key] = value;
+  }
+  removeItem(key: string): void {
+    delete this.store[key];
+  }
+}

--- a/packages/dharma-core/src/lib/createPersistentStore.test.ts
+++ b/packages/dharma-core/src/lib/createPersistentStore.test.ts
@@ -7,11 +7,10 @@ import {
 
 describe("createPersistentStore", () => {
   const key = "test";
+  const initKey = `init_${key}`;
   const initialState = { count: 0 };
   const listener = vi.fn();
   const defineActions = vi.fn();
-  const initKey = `init_${key}`;
-  const storeKey = `store_${key}`;
 
   beforeEach(() => {
     localStorage.clear();
@@ -27,13 +26,13 @@ describe("createPersistentStore", () => {
     const store = createPersistentStore({ key, initialState, defineActions });
     store.subscribe(listener);
     store.set({ count: 1 });
-    const storedState = localStorage.getItem(storeKey);
+    const storedState = localStorage.getItem(key);
     expect(storedState).toBe(JSON.stringify({ count: 1 }));
   });
 
   it("should load state from localStorage if available", () => {
     localStorage.setItem(initKey, JSON.stringify({ count: 0 }));
-    localStorage.setItem(storeKey, JSON.stringify({ count: 1 }));
+    localStorage.setItem(key, JSON.stringify({ count: 1 }));
     const store = createPersistentStore({ key, initialState, defineActions });
     expect(store.get()).toEqual({ count: 0 });
     store.subscribe(listener);
@@ -42,7 +41,7 @@ describe("createPersistentStore", () => {
 
   it("should load state from sessionStorage if available", () => {
     sessionStorage.setItem(initKey, JSON.stringify({ count: 0 }));
-    sessionStorage.setItem(storeKey, JSON.stringify({ count: 2 }));
+    sessionStorage.setItem(key, JSON.stringify({ count: 2 }));
     const store = createPersistentStore({
       key,
       initialState,
@@ -57,7 +56,7 @@ describe("createPersistentStore", () => {
     const store = createPersistentStore({ key, initialState, defineActions });
     store.subscribe(listener);
     store.set({ count: 1 });
-    localStorage.setItem(storeKey, JSON.stringify({ count: 2 }));
+    localStorage.setItem(key, JSON.stringify({ count: 2 }));
     window.dispatchEvent(new Event("focus"));
     expect(store.get()).toEqual({ count: 2 });
   });
@@ -91,7 +90,7 @@ describe("createPersistentStore", () => {
     });
     store.set({ count: 1 });
     expect(customStorage.setItem).toHaveBeenCalledWith(
-      storeKey,
+      key,
       JSON.stringify({ count: 1 }),
     );
   });

--- a/packages/dharma-core/src/lib/createPersistentStore.ts
+++ b/packages/dharma-core/src/lib/createPersistentStore.ts
@@ -17,7 +17,7 @@ export type PersistentStoreConfiguration<
   TActions extends object,
 > = StoreConfiguration<TState, TActions> & {
   key: string;
-  /** The storage to use for persisting the state. Defaults to local storage. */
+  /** The storage to use for persisting the state. Defaults to local storage if available. */
   storage?: StorageAPI;
   /** The serializer to use for storing the state. Defaults to JSON. */
   serializer?: Serializer<TState>;
@@ -72,44 +72,47 @@ export const createPersistentStore = <
   TState extends object,
   TActions extends object = Record<never, never>,
 >(
-  options: PersistentStoreConfiguration<TState, TActions>,
+  config: PersistentStoreConfiguration<TState, TActions>,
 ): Store<TState, TActions> => {
-  if (typeof window === "undefined") {
-    return createStore(options);
-  }
-
   const {
     key,
     initialState,
-    storage = localStorage,
+    storage: customStorage,
     serializer = JSON,
     onAttach,
     onDetach,
     onChange,
     ...rest
-  } = options;
+  } = config;
 
-  const stateKey = `store_${key}`;
+  const IS_BROWSER = typeof window !== "undefined";
+  const storage = customStorage ?? (IS_BROWSER ? localStorage : undefined);
+
+  if (!storage) {
+    return createStore(config);
+  }
+
   const initialStateKey = `init_${key}`;
+
   const initialStateSnapshot = storage.getItem(initialStateKey);
   const initialStateString = serializer.stringify(initialState);
 
   if (initialStateSnapshot !== initialStateString) {
     storage.setItem(initialStateKey, initialStateString);
-    storage.removeItem(stateKey);
+    storage.removeItem(key);
   }
 
   const updateSnapshot = (newState: TState) => {
-    const currentSnapshot = storage.getItem(stateKey);
+    const currentSnapshot = storage.getItem(key);
     const newSnapshot = serializer.stringify(newState);
 
     if (newSnapshot !== currentSnapshot) {
-      storage.setItem(stateKey, newSnapshot);
+      storage.setItem(key, newSnapshot);
     }
   };
 
   const updateState = () => {
-    const currentSnapshot = storage.getItem(stateKey);
+    const currentSnapshot = storage.getItem(key);
 
     if (
       currentSnapshot &&
@@ -124,11 +127,15 @@ export const createPersistentStore = <
     onAttach: (ctx) => {
       onAttach?.(ctx);
       updateState();
-      window.addEventListener("focus", updateState);
+      if (IS_BROWSER) {
+        window.addEventListener("focus", updateState);
+      }
     },
     onDetach: (ctx) => {
       onDetach?.(ctx);
-      window.removeEventListener("focus", updateState);
+      if (IS_BROWSER) {
+        window.removeEventListener("focus", updateState);
+      }
     },
     onChange: ({ state, ...ctx }) => {
       onChange?.({ state, ...ctx });

--- a/packages/dharma-core/src/lib/merge.ts
+++ b/packages/dharma-core/src/lib/merge.ts
@@ -4,8 +4,8 @@ import { StateModifier } from "./createStore";
  * Merges the current state with a state modifier.
  * Useful for creating custom set functions.
  *
- * @param {T} stateModifier - A function or object that modifies the state.
- * @param {StateModifier<T>} stateModifier - The current state object.
+ * @param {T} currentState - The current state object.
+ * @param {StateModifier<T>} stateModifier - A function or object that modifies the state.
  * @returns {T} The new state object, which is a combination of the current state and the state modifier.
  *
  * @example

--- a/packages/dharma-react/src/lib/useStore.ts
+++ b/packages/dharma-react/src/lib/useStore.ts
@@ -5,7 +5,7 @@ import { deeplyEquals } from "./deeplyEquals";
 /**
  * A hook used to access a store created with `createStore` and bind it to a component.
  *
- * @param {Store<TState, TActions, TSelection>} store - The store created with `createStore`.
+ * @param {Store<TState, TActions>} store - The store created with `createStore`.
  * @param {(state: TState) => TSelection} [select] - A function to select a subset of the state. Can prevent unnecessary re-renders.
  * @returns {TSelection} The selected state from the store.
  *


### PR DESCRIPTION
## dharma-core

- createPersistentStorage: The storage option now only supports storage objects (previously "local" and "session")
- createPersistentStorage now works in non-browser environments if a storage is provided
- jsdoc updates

## dharma-react

- jsdoc updates