### PR TITLE
refactor: move all storage logic to createStorageAdapter

### DIFF
--- a/.changeset/rotten-pets-judge.md
+++ b/.changeset/rotten-pets-judge.md
@@ -1,0 +1,5 @@
+---
+"dharma-core": patch
+---
+
+Renamed StoreEventHandler to StoreEventListener

--- a/packages/dharma-core/src/lib/createStorageAdapter.ts
+++ b/packages/dharma-core/src/lib/createStorageAdapter.ts
@@ -6,7 +6,6 @@ export const createStorageAdapter = <
   TActions extends object = Record<never, never>,
 >(
   config: StoreConfig<TState, TActions>,
-  isBrowser: boolean,
   get: () => TState,
   set: SetState<TState>,
 ) => {
@@ -14,8 +13,10 @@ export const createStorageAdapter = <
     return null;
   }
 
+  const IS_BROWSER = typeof window !== "undefined";
+
   const storage =
-    config.storage ?? (isBrowser ? (localStorage as StorageAPI) : undefined);
+    config.storage ?? (IS_BROWSER ? (localStorage as StorageAPI) : undefined);
 
   if (!storage) {
     warn(
@@ -27,7 +28,7 @@ export const createStorageAdapter = <
   const { key, serializer = JSON, initialState } = config;
   const initKey = `init_${key}`;
 
-  const initializeSnapshots = async () => {
+  const onLoad = async () => {
     try {
       let initialStateSnapshot = storage.getItem(initKey);
       const initialStateString = serializer.stringify(initialState);
@@ -40,6 +41,10 @@ export const createStorageAdapter = <
         storage.setItem(initKey, initialStateString);
         storage.removeItem(key);
       }
+
+      if (IS_BROWSER) {
+        window.addEventListener("focus", onAttach);
+      }
     } catch {
       warn(
         "Failed to initialize snapshots. If this happened during SSR, you can safely ignore this warning.",
@@ -47,7 +52,7 @@ export const createStorageAdapter = <
     }
   };
 
-  const updateSnapshot = async (newState: TState) => {
+  const onChange = async (newState: TState) => {
     try {
       let currentSnapshot = storage.getItem(key);
       const newSnapshot = serializer.stringify(newState);
@@ -64,7 +69,7 @@ export const createStorageAdapter = <
     }
   };
 
-  const updateState = async () => {
+  const onAttach = async () => {
     try {
       let currentSnapshot = storage.getItem(key);
 
@@ -80,9 +85,16 @@ export const createStorageAdapter = <
     }
   };
 
+  const onDetach = () => {
+    if (IS_BROWSER) {
+      window.removeEventListener("focus", onAttach);
+    }
+  };
+
   return {
-    initializeSnapshots,
-    updateSnapshot,
-    updateState,
+    onLoad,
+    onChange,
+    onAttach,
+    onDetach,
   };
 };

--- a/packages/dharma-core/src/lib/createStorageAdapter.ts
+++ b/packages/dharma-core/src/lib/createStorageAdapter.ts
@@ -28,22 +28,6 @@ export const createStorageAdapter = <
   const { key, serializer = JSON, initialState } = config;
   const initKey = `init_${key}`;
 
-  const syncWithSnapshot = async () => {
-    try {
-      let currentSnapshot = storage.getItem(key);
-
-      if (currentSnapshot instanceof Promise) {
-        currentSnapshot = await currentSnapshot;
-      }
-
-      if (currentSnapshot && currentSnapshot !== serializer.stringify(get())) {
-        set(serializer.parse(currentSnapshot));
-      }
-    } catch {
-      warn("Failed to update state from snapshot");
-    }
-  };
-
   const onLoad = async () => {
     try {
       let initialStateSnapshot = storage.getItem(initKey);
@@ -64,7 +48,23 @@ export const createStorageAdapter = <
     }
   };
 
-  const onAttach = async () => {
+  const syncWithSnapshot = async () => {
+    try {
+      let currentSnapshot = storage.getItem(key);
+
+      if (currentSnapshot instanceof Promise) {
+        currentSnapshot = await currentSnapshot;
+      }
+
+      if (currentSnapshot && currentSnapshot !== serializer.stringify(get())) {
+        set(serializer.parse(currentSnapshot));
+      }
+    } catch {
+      warn("Failed to update state from snapshot");
+    }
+  };
+
+  const onAttach = () => {
     syncWithSnapshot();
 
     if (IS_BROWSER) {

--- a/packages/dharma-core/src/lib/createStore.test.ts
+++ b/packages/dharma-core/src/lib/createStore.test.ts
@@ -177,6 +177,23 @@ describe("createStore", () => {
       expect(store.get()).toEqual({ count: 2 });
     });
 
+    it("should add and remove focus event listener once", () => {
+      const addEventListenerSpy = vi.spyOn(window, "addEventListener");
+      const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+      const store = createStore({
+        persist: true,
+        key,
+        initialState,
+        defineActions,
+      });
+      const unsubscribe = store.subscribe(vi.fn());
+      const unsubscribe2 = store.subscribe(vi.fn());
+      expect(addEventListenerSpy).toHaveBeenCalledOnce();
+      unsubscribe();
+      unsubscribe2();
+      expect(removeEventListenerSpy).toHaveBeenCalledOnce();
+    });
+
     it("should use custom serializer", () => {
       const customSerializer: Serializer = {
         stringify: vi.fn(),

--- a/packages/dharma-core/src/lib/createStore.ts
+++ b/packages/dharma-core/src/lib/createStore.ts
@@ -29,7 +29,7 @@ export type StoreEventContext<TState extends object> = {
   reset: () => TState;
 };
 
-export type StoreEventHandler<TState extends object> = (
+export type StoreEventListener<TState extends object> = (
   context: StoreEventContext<TState>,
 ) => void;
 
@@ -56,13 +56,13 @@ export type BaseConfig<TState extends object, TActions extends object> = {
   /** A function that defines actions that can modify the state. */
   defineActions?: DefineActions<TState, TActions>;
   /** Invoked when the store is created. */
-  onLoad?: StoreEventHandler<TState>;
+  onLoad?: StoreEventListener<TState>;
   /** Invoked when the store is subscribed to. */
-  onAttach?: StoreEventHandler<TState>;
+  onAttach?: StoreEventListener<TState>;
   /** Invoked when the store is unsubscribed from. */
-  onDetach?: StoreEventHandler<TState>;
+  onDetach?: StoreEventListener<TState>;
   /** Invoked whenever the state changes. */
-  onChange?: StoreEventHandler<TState>;
+  onChange?: StoreEventListener<TState>;
 };
 
 export type MaybePromise<T> = T | Promise<T>;
@@ -122,7 +122,7 @@ export type StoreConfig<
  * ```
  *
  * @example
- * With event handlers:
+ * With event listeners:
  * ```ts
  * import { createStore } from "dharma-core";
  * import { State } from "./types";

--- a/packages/dharma-core/src/lib/createStore.ts
+++ b/packages/dharma-core/src/lib/createStore.ts
@@ -218,17 +218,12 @@ export const createStore = <
   const actions = defineActions
     ? defineActions({ set, get, reset })
     : ({} as TActions);
-  const IS_BROWSER = typeof window !== "undefined";
-  const storageAdapter = createStorageAdapter(config, IS_BROWSER, get, set);
+  const storageAdapter = createStorageAdapter(config, get, set);
 
   const subscribe = (listener: Listener<TState>) => {
     if (listeners.size === 0) {
       onAttach?.({ state, set, reset });
-      storageAdapter?.updateState();
-
-      if (IS_BROWSER && storageAdapter) {
-        window.addEventListener("focus", storageAdapter.updateState);
-      }
+      storageAdapter?.onAttach();
     }
 
     listener(state);
@@ -239,10 +234,7 @@ export const createStore = <
 
       if (listeners.size === 0) {
         onDetach?.({ state, set, reset });
-
-        if (IS_BROWSER && storageAdapter) {
-          window.removeEventListener("focus", storageAdapter.updateState);
-        }
+        storageAdapter?.onDetach();
       }
     };
   };
@@ -253,12 +245,12 @@ export const createStore = <
       set: setSilently,
       reset: resetSilently,
     });
-    storageAdapter?.updateSnapshot(state);
+    storageAdapter?.onChange(state);
     listeners.forEach((listener) => listener(state));
   };
 
   onLoad?.({ state, set, reset });
-  storageAdapter?.initializeSnapshots();
+  storageAdapter?.onLoad();
 
   return {
     get,


### PR DESCRIPTION
This pull request refactors the storage adapter logic in the `dharma-core` package to improve clarity, encapsulation, and browser environment detection. The main changes involve renaming lifecycle methods for better semantics, moving browser checks inside the storage adapter, and consolidating event listener management.

**Refactoring and Encapsulation Improvements:**

* Moved browser environment detection (`IS_BROWSER`) from `createStore` to within `createStorageAdapter`, removing the need to pass it as a parameter and centralizing environment checks.
* Renamed storage adapter lifecycle methods for clarity: `initializeSnapshots` → `onLoad`, `updateSnapshot` → `onChange`, and `updateState` → `onAttach`. Added a new `onDetach` method for cleanup. [[1]](diffhunk://#diff-b55f8e12c083046b859f41aa6e66cbd3064398d5803e8051296c171ac6fc83a6L30-R31) [[2]](diffhunk://#diff-b55f8e12c083046b859f41aa6e66cbd3064398d5803e8051296c171ac6fc83a6R44-R55) [[3]](diffhunk://#diff-b55f8e12c083046b859f41aa6e66cbd3064398d5803e8051296c171ac6fc83a6L67-R72) [[4]](diffhunk://#diff-b55f8e12c083046b859f41aa6e66cbd3064398d5803e8051296c171ac6fc83a6R88-R98)
* Updated `createStore.ts` to use the new storage adapter method names and to delegate all event listener management (e.g., attaching and detaching `focus` event handlers) to the storage adapter, reducing duplication and improving encapsulation. [[1]](diffhunk://#diff-287e7556d48dea6ea5c1101e26628b47826ad1538735a9d930466a8a6ceca173L221-R226) [[2]](diffhunk://#diff-287e7556d48dea6ea5c1101e26628b47826ad1538735a9d930466a8a6ceca173L242-R237) [[3]](diffhunk://#diff-287e7556d48dea6ea5c1101e26628b47826ad1538735a9d930466a8a6ceca173L256-R253)