### PR TITLE
feat: encapsulate state management

### DIFF
--- a/.changeset/proud-bananas-burn.md
+++ b/.changeset/proud-bananas-burn.md
@@ -1,0 +1,6 @@
+---
+"dharma-react": minor
+"dharma-core": minor
+---
+
+stores no longer expose set and reset methods

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,11 +4,11 @@
 
 ## Checklist before merge
 
-_check for yes or N/A_
+_Check for yes or N/A_
 
-- [ ] PR title has format `type: summary`*
+- [ ] PR title has format `type: summary`\*
 - [ ] Changeset created if type is `feat` or `fix`
 - [ ] New code is covered by unit tests
 - [ ] Documentation updated
 
-*Valid types: feat, fix, chore, test, refactor, docs
+\*Valid types: feat, fix, chore, test, refactor, docs

--- a/apps/docs/src/content/docs/core/createstore.md
+++ b/apps/docs/src/content/docs/core/createstore.md
@@ -17,8 +17,6 @@ const store = createStore(config);
 The created store with state management methods.
 
 - `get` - Returns the current state of the store.
-- `set` - Sets the state of the store.
-- `reset` - Resets the state of the store to its initial value.
 - `actions` - Actions that can modify the state of the store.
 - `subscribe` - Subscribes to changes in the state of the store. Returns an unsubscribe function.
 

--- a/apps/docs/src/content/docs/react/api/usestorecontext.md
+++ b/apps/docs/src/content/docs/react/api/usestorecontext.md
@@ -19,8 +19,6 @@ The store instance.
 
 - `state` - The current state of the store.
 - `actions` - The actions that can modify the state of the store.
-- `set` - Sets the state of the store.
-- `reset` - Resets the state of the store to its initial value.
 
 ## Usage
 

--- a/packages/dharma-core/src/lib/createStore.node.test.ts
+++ b/packages/dharma-core/src/lib/createStore.node.test.ts
@@ -1,15 +1,15 @@
 // @vitest-environment node
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createStore } from "./createStore";
-import { StorageAPI } from "./types";
+import { StateHandler, StorageAPI } from "./types";
 
 describe("createStore (node)", () => {
   const baseConfig = {
     persist: true,
     key: "test",
     initialState: { count: 0 },
-    defineActions: vi.fn(),
+    defineActions: (handler: StateHandler<{ count: number }>) => handler,
   };
 
   it("should not throw in a node environment", () => {
@@ -20,7 +20,7 @@ describe("createStore (node)", () => {
     const storage = new CustomStorage();
     const store = createStore({ ...baseConfig, storage });
     expect(storage.getItem("init_test")).toBe(JSON.stringify({ count: 0 }));
-    store.set({ count: 1 });
+    store.actions.set({ count: 1 });
     expect(storage.getItem("test")).toBe(JSON.stringify({ count: 1 }));
   });
 });

--- a/packages/dharma-core/src/lib/createStore.test.ts
+++ b/packages/dharma-core/src/lib/createStore.test.ts
@@ -1,5 +1,4 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStore } from "./createStore";
 import { Serializer, StateHandler, StorageAPI } from "./types";

--- a/packages/dharma-core/src/lib/createStore.test.ts
+++ b/packages/dharma-core/src/lib/createStore.test.ts
@@ -1,6 +1,6 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { afterEach } from "node:test";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStore } from "./createStore";
 import { Serializer, StateHandler, StorageAPI } from "./types";
 

--- a/packages/dharma-core/src/lib/createStore.test.ts
+++ b/packages/dharma-core/src/lib/createStore.test.ts
@@ -1,42 +1,45 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { afterEach } from "node:test";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createStore } from "./createStore";
-import { Serializer, StorageAPI } from "./types";
+import { Serializer, StateHandler, StorageAPI } from "./types";
 
 describe("createStore", () => {
-  const defineActions = vi.fn();
+  interface State {
+    count: number;
+  }
+  const initialState = { count: 0 };
+  const defineActions = (handler: StateHandler<State>) => handler;
+  const store = createStore({
+    initialState,
+    defineActions,
+  });
+
+  afterEach(store.actions.reset);
 
   it("should initialize with the given state", () => {
-    const initialState = { count: 0 };
-    const store = createStore({ initialState, defineActions });
     expect(store.get()).toEqual(initialState);
   });
 
   it("should update the state using set and reset", () => {
-    const initialState = { count: 0 };
-    const store = createStore({ initialState, defineActions });
-    store.set({ count: 1 });
+    store.actions.set({ count: 1 });
     expect(store.get().count).toBe(1);
-    store.reset();
+    store.actions.reset();
     expect(store.get().count).toBe(0);
   });
 
   it("should notify subscribers on state change", () => {
-    const initialState = { count: 0 };
-    const store = createStore({ initialState, defineActions });
     const listener = vi.fn();
     store.subscribe(listener);
-    store.set({ count: 1 });
+    store.actions.set({ count: 1 });
     expect(listener).toHaveBeenCalledTimes(2);
   });
 
   it("should unsubscribe listeners correctly", () => {
-    const initialState = { count: 0 };
-    const store = createStore({ initialState, defineActions });
     const listener = vi.fn();
     const unsubscribe = store.subscribe(listener);
     unsubscribe();
-    store.set({ count: 1 });
+    store.actions.set({ count: 1 });
     expect(listener).toHaveBeenCalledOnce();
   });
 
@@ -62,7 +65,7 @@ describe("createStore", () => {
       defineActions,
       onChange: ({ state, set }) => set({ other: state.other + "bar" }),
     });
-    store.set({ count: 1 });
+    store.actions.set({ count: 1 });
     expect(store.get()).toEqual({ count: 1, other: "foobar" });
   });
 
@@ -106,7 +109,6 @@ describe("createStore", () => {
     const initKey = `init_${key}`;
     const initialState = { count: 0 };
     const listener = vi.fn();
-    const defineActions = vi.fn();
 
     beforeEach(() => {
       localStorage.clear();
@@ -131,7 +133,7 @@ describe("createStore", () => {
         defineActions,
       });
       store.subscribe(listener);
-      store.set({ count: 1 });
+      store.actions.set({ count: 1 });
       const storedState = localStorage.getItem(key);
       expect(storedState).toBe(JSON.stringify({ count: 1 }));
     });
@@ -172,7 +174,7 @@ describe("createStore", () => {
         defineActions,
       });
       store.subscribe(listener);
-      store.set({ count: 1 });
+      store.actions.set({ count: 1 });
       localStorage.setItem(key, JSON.stringify({ count: 2 }));
       window.dispatchEvent(new Event("focus"));
       expect(store.get()).toEqual({ count: 2 });
@@ -207,7 +209,7 @@ describe("createStore", () => {
         defineActions,
         serializer: customSerializer,
       });
-      store.set({ count: 1 });
+      store.actions.set({ count: 1 });
       expect(customSerializer.stringify).toHaveBeenCalledWith({ count: 1 });
     });
 
@@ -224,7 +226,7 @@ describe("createStore", () => {
         defineActions,
         storage: customStorage,
       });
-      store.set({ count: 1 });
+      store.actions.set({ count: 1 });
       expect(customStorage.setItem).toHaveBeenCalledWith(
         key,
         JSON.stringify({ count: 1 }),
@@ -242,7 +244,7 @@ describe("createStore", () => {
         storage: AsyncStorage,
       });
 
-      await Promise.resolve(store.set({ count: 1 }));
+      await Promise.resolve(store.actions.set({ count: 1 }));
       const expectedSnapshot = JSON.stringify({ count: 1 });
       const snapshot = await AsyncStorage.getItem(key);
       expect(AsyncStorage.setItem).toHaveBeenCalledWith(key, expectedSnapshot);

--- a/packages/dharma-core/src/lib/createStore.ts
+++ b/packages/dharma-core/src/lib/createStore.ts
@@ -156,8 +156,6 @@ export const createStore = <
 
   return {
     get,
-    set,
-    reset,
     subscribe,
     actions,
   };

--- a/packages/dharma-core/src/lib/types.ts
+++ b/packages/dharma-core/src/lib/types.ts
@@ -7,10 +7,6 @@ export type SetState<TState extends object> = (
 export type Store<TState extends object, TActions extends object> = {
   /** Returns the current state of the store. */
   get: () => TState;
-  /** Sets the state of the store. */
-  set: SetState<TState>;
-  /** Resets the state of the store to its initial value. */
-  reset: () => TState;
   /** Actions that can modify the state of the store. */
   actions: TActions;
   /** Subscribes to changes in the state of the store. Returns an unsubscribe function. */

--- a/packages/dharma-react/src/lib/types.ts
+++ b/packages/dharma-react/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { StateModifier, Store } from "dharma-core";
+import { Store } from "dharma-core";
 
 export type StoreContext<
   TArgs extends unknown[],
@@ -16,6 +16,4 @@ export type BoundStore<
 > = {
   state: TSelection;
   actions: TActions;
-  set: (stateModifier: StateModifier<TState>) => TState;
-  reset: () => TState;
 };

--- a/packages/dharma-react/src/lib/useStoreContext.test.tsx
+++ b/packages/dharma-react/src/lib/useStoreContext.test.tsx
@@ -40,8 +40,6 @@ describe("useStoreContext", () => {
     const { result } = renderUseStoreContext();
     expect(result.current).toStrictEqual({
       state: { count: 0 },
-      set: expect.any(Function),
-      reset: expect.any(Function),
       actions: {
         increment: expect.any(Function),
         decrement: expect.any(Function),

--- a/packages/dharma-react/src/lib/useStoreContext.ts
+++ b/packages/dharma-react/src/lib/useStoreContext.ts
@@ -57,7 +57,8 @@ export const useStoreContext = <
       "Store context not found. Make sure you are using the store context within a provider.",
     );
   }
-  const state = useStore(store, select);
-  const { actions, set, reset } = store;
-  return { state, actions, set, reset };
+  return {
+    state: useStore(store, select),
+    actions: store.actions,
+  };
 };


### PR DESCRIPTION
## Description

Stores no longer expose set and reset methods. The store itself should encapsulate the logic of how its state is managed. 

## Related issue(s)

## Checklist before merge

_check for yes or N/A_

- [x] PR title has format `type: summary`*
- [x] Changeset created if type is `feat` or `fix`
- [x] New code is covered by unit tests
- [x] Documentation updated

*Valid types: feat, fix, chore, test, refactor, docs
