### PR TITLE
feat: createEffect

### DIFF
--- a/.changeset/common-waves-tan.md
+++ b/.changeset/common-waves-tan.md
@@ -1,0 +1,5 @@
+---
+"dharma-core": minor
+---
+
+createEffect: a new utility that creates a side-effect

--- a/.changeset/tidy-icons-live.md
+++ b/.changeset/tidy-icons-live.md
@@ -1,0 +1,5 @@
+---
+"dharma-core": patch
+---
+
+derive: mount returns the unmount function

--- a/apps/demo/src/components/Examples.tsx
+++ b/apps/demo/src/components/Examples.tsx
@@ -5,6 +5,7 @@ import { Async } from "./examples/Async";
 import { Context } from "./examples/Context";
 import { Counter } from "./examples/Counter";
 import { Derived } from "./examples/Derived";
+import { Effect } from "./examples/Effect";
 import { Persistent } from "./examples/Persistent";
 import { PersistentAsync } from "./examples/PersistentAsync";
 import { Shared } from "./examples/Shared";
@@ -24,6 +25,9 @@ export const CounterExample: FC<Props> = ({ children }) => (
 );
 export const DerivedExample: FC<Props> = ({ children }) => (
   <CodeToggle component={<Derived />}>{children}</CodeToggle>
+);
+export const EffectExample: FC<Props> = ({ children }) => (
+  <CodeToggle component={<Effect />}>{children}</CodeToggle>
 );
 export const PersistentExample: FC<Props> = ({ children }) => (
   <CodeToggle component={<Persistent />}>{children}</CodeToggle>

--- a/apps/demo/src/components/Nav.tsx
+++ b/apps/demo/src/components/Nav.tsx
@@ -18,6 +18,7 @@ const links: NavLink[] = [
   { href: "/async-storage", label: "Async Storage" },
   { href: "/async", label: "Async" },
   { href: "/derived", label: "Derived" },
+  { href: "/effect", label: "Effect" },
 ];
 
 export default function Nav() {

--- a/apps/demo/src/components/examples/Effect.tsx
+++ b/apps/demo/src/components/examples/Effect.tsx
@@ -1,0 +1,40 @@
+import { createEffect, createStore } from "dharma-core";
+import { useStore } from "dharma-react";
+import { useEffect } from "react";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+
+const store = createStore({
+  initialState: { count: 0, input: "" },
+  defineActions: ({ set }) => ({
+    increment: () => set((state) => ({ count: state.count + 1 })),
+    decrement: () => set((state) => ({ count: state.count - 1 })),
+    setInput: (input: string) => set({ input }),
+  }),
+});
+
+const { increment, decrement, setInput } = store.actions;
+
+const effect = createEffect(
+  store,
+  (state) => console.log(`count = ${state.count}`),
+  (state) => [state.count],
+);
+
+export const Effect = () => {
+  const { count, input } = useStore(store);
+  useEffect(effect.mount, []);
+
+  return (
+    <div className="grid grid-cols-3 text-center items-center w-fit gap-y-2">
+      <Button onClick={decrement}>-</Button>
+      <div aria-label="count">{count}</div>
+      <Button onClick={increment}>+</Button>
+      <Input
+        className="col-span-3"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+      />
+    </div>
+  );
+};

--- a/apps/demo/src/pages/effect.astro
+++ b/apps/demo/src/pages/effect.astro
@@ -1,0 +1,12 @@
+---
+import { Code } from 'astro/components';
+import code from '../components/examples/Effect?raw';
+import { EffectExample } from '../components/Examples';
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout>
+  <EffectExample client:load>
+    <Code code={code} lang='tsx' class='p-4 rounded-lg' />
+  </EffectExample>
+</Layout>

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -30,6 +30,7 @@ export default defineConfig({
           items: [
             "core/quick-start",
             "core/createstore",
+            "core/createeffect",
             "core/derive",
             "core/merge",
           ],

--- a/apps/docs/src/content/docs/core/createeffect.mdx
+++ b/apps/docs/src/content/docs/core/createeffect.mdx
@@ -1,0 +1,38 @@
+---
+title: createEffect
+description: createEffect API reference.
+---
+
+Creates an effect that runs when the store's state changes.
+
+```ts
+const effect = createEffect(store, effectFn, dependencyFn?);
+```
+
+## Parameters
+
+- `store` - The store instance to subscribe to
+- `effectFn` - The function to run when dependencies change. Receives the current state as argument.
+- `dependencyFn?` - Optional function that returns an array of dependencies. If provided, the effect will only run when these dependencies change.
+
+## Returns
+
+An `Effect` object with the following methods:
+
+- `mount` - Start listening to changes in the original store.
+- `unmount` - Stop listening to changes in the original store.
+
+## Usage
+
+```ts
+import { createEffect } from "dharma-core";
+import { counterStore } from "./counterStore";
+
+const countLogger = createEffect(
+  counterStore,
+  (state) => console.log("count =", state.count),
+  (state) => [state.count],
+);
+
+countLogger.mount();
+```

--- a/apps/docs/src/content/docs/react/quick-start.mdx
+++ b/apps/docs/src/content/docs/react/quick-start.mdx
@@ -3,52 +3,54 @@ title: Quick Start
 description: Get started with dharma-react.
 ---
 
-import { Steps } from '@astrojs/starlight/components';
-import PackageManager from '../../../components/PackageManager.astro'
+import { Steps } from "@astrojs/starlight/components";
+import PackageManager from "../../../components/PackageManager.astro";
 
 <Steps>
 
 1. Install the packages:
 
-    <PackageManager 
-      npm="npm install dharma-core dharma-react" 
-      pnpm="pnpm add dharma-core dharma-react" 
-      yarn="yarn add dharma-core dharma-react"
-    />
+   <PackageManager
+     npm="npm install dharma-core dharma-react"
+     pnpm="pnpm add dharma-core dharma-react"
+     yarn="yarn add dharma-core dharma-react"
+   />
 
 2. Create a store:
 
-    ```ts
-    import { createStore } from "dharma-core";
+   ```ts
+   // store.ts
+   import { createStore } from "dharma-core";
 
-    export const store = createStore({
-      initialState: { count: 0 },
-      defineActions: ({ set }) => ({
-        increment: () => set((state) => ({ count: state.count + 1 })),
-        decrement: () => set((state) => ({ count: state.count - 1 })),
-      }),
-    });
+   export const store = createStore({
+     initialState: { count: 0 },
+     defineActions: ({ set }) => ({
+       increment: () => set((state) => ({ count: state.count + 1 })),
+       decrement: () => set((state) => ({ count: state.count - 1 })),
+     }),
+   });
 
-    export const { increment, decrement } = store.actions;
-    ```
+   export const { increment, decrement } = store.actions;
+   ```
 
 3. Use the store:
 
-    ```tsx
-    import { useStore } from "dharma-react";
-    import { decrement, increment, store } from "./store";
+   ```tsx
+   // Counter.tsx
+   import { useStore } from "dharma-react";
+   import { decrement, increment, store } from "./store";
 
-    function Counter() {
-      const { count } = useStore(store);
+   function Counter() {
+     const { count } = useStore(store);
 
-      return (
-        <div>
-          <div>{count}</div>
-          <button onClick={decrement}>-</button>
-          <button onClick={increment}>+</button>
-        </div>
-      );
-    }
-    ```
+     return (
+       <div>
+         <div>{count}</div>
+         <button onClick={decrement}>-</button>
+         <button onClick={increment}>+</button>
+       </div>
+     );
+   }
+   ```
 
 </Steps>

--- a/packages/dharma-core/src/index.ts
+++ b/packages/dharma-core/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./lib/createEffect";
 export * from "./lib/createStore";
 export * from "./lib/derive";
 export * from "./lib/merge";

--- a/packages/dharma-core/src/lib/createEffect.test.ts
+++ b/packages/dharma-core/src/lib/createEffect.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEffect } from "./createEffect";
+import { createStore } from "./createStore";
+
+describe("createEffect", () => {
+  const onAttach = vi.fn();
+  const onDetach = vi.fn();
+
+  const store = createStore({
+    initialState: { count: 0, other: "foo" },
+    defineActions: ({ set, reset }) => ({
+      increment: () => set((state) => ({ count: state.count + 1 })),
+      decrement: () => set((state) => ({ count: state.count - 1 })),
+      reset: () => reset(),
+      setOther: (other: string) => set({ other }),
+    }),
+    onAttach,
+    onDetach,
+  });
+
+  const { increment, setOther, reset } = store.actions;
+
+  const effectFn = vi.fn();
+
+  afterEach(() => {
+    reset();
+    vi.clearAllMocks();
+  });
+
+  it("should run the effect when the store changes", () => {
+    const effect = createEffect(store, effectFn);
+    effect.mount();
+    expect(effectFn).toHaveBeenCalledTimes(1); // Initial run
+    increment();
+    expect(effectFn).toHaveBeenCalledTimes(2);
+    effect.unmount();
+  });
+
+  it("should not run the effect if dependencies have not changed", () => {
+    const effect = createEffect(
+      store,
+      (state) => effectFn(state.count),
+      (state) => [state.count],
+    );
+    effect.mount();
+    expect(effectFn).toHaveBeenCalledTimes(1);
+    increment();
+    expect(effectFn).toHaveBeenCalledTimes(2);
+    setOther("bar");
+    expect(effectFn).toHaveBeenCalledTimes(2); // Should not run again
+    effect.unmount();
+  });
+
+  it("should subscribe to the store on mount and unsubscribe on unmount", () => {
+    const effect = createEffect(store, effectFn);
+    expect(onAttach).not.toHaveBeenCalled();
+    effect.mount();
+    expect(onAttach).toHaveBeenCalledTimes(1);
+    effect.unmount();
+    expect(onDetach).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not run the effect after unmounting", () => {
+    const effect = createEffect(store, effectFn);
+    effect.mount();
+    expect(effectFn).toHaveBeenCalledTimes(1);
+    effect.unmount();
+    increment();
+    expect(effectFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should pass the store's state to the effect function", () => {
+    const effect = createEffect(store, (state) => effectFn(state));
+    effect.mount();
+    expect(effectFn).toHaveBeenCalledWith({ count: 0, other: "foo" });
+    increment();
+    expect(effectFn).toHaveBeenCalledWith({ count: 1, other: "foo" });
+    effect.unmount();
+  });
+});

--- a/packages/dharma-core/src/lib/createEffect.ts
+++ b/packages/dharma-core/src/lib/createEffect.ts
@@ -1,0 +1,50 @@
+import { Effect, Store } from "../types/types";
+import { deeplyEquals } from "./deeplyEquals";
+
+/**
+ * Creates an effect that runs when the store's state changes.
+ *
+ * @param store - The store instance to subscribe to
+ * @param effectFn - The function to run when dependencies change. Receives the current state as argument.
+ * @param dependencyFn - Optional function that returns an array of dependencies. If provided, the effect will only run when these dependencies change.
+ *
+ * @returns An Effect object with mount and unmount methods
+ *
+ * @see {@link https://dharma.fransek.dev/core/createeffect/}
+ */
+export const createEffect = <TState, TActions, TDerived>(
+  store: Store<TState, TActions>,
+  effectFn: (state: TState) => TDerived,
+  dependencyFn?: (state: TState) => unknown[],
+): Effect => {
+  let prev: unknown[] | undefined;
+  let unsubscribe: (() => void) | undefined;
+
+  const execute = () => effectFn(store.get());
+
+  const effect = () => {
+    const next = dependencyFn?.(store.get());
+
+    if (!prev || !deeplyEquals(prev, next)) {
+      prev = next;
+      execute();
+    }
+  };
+
+  const mount = () => {
+    if (!unsubscribe) {
+      unsubscribe = store.subscribe(effect);
+    }
+    return unmount;
+  };
+
+  const unmount = () => {
+    unsubscribe?.();
+    unsubscribe = undefined;
+  };
+
+  return {
+    mount,
+    unmount,
+  };
+};

--- a/packages/dharma-core/src/lib/derive.ts
+++ b/packages/dharma-core/src/lib/derive.ts
@@ -33,15 +33,7 @@ export const derive = <TState, TActions, TDerived>(
   };
 
   const get = () => {
-    if (!dependencyFn) {
-      if (isStale) {
-        return compute();
-      }
-
-      return memo as TDerived;
-    }
-
-    const next = dependencyFn(store.get());
+    const next = dependencyFn?.(store.get());
     isStale &&= !prev || !deeplyEquals(prev, next);
 
     if (isStale) {
@@ -69,13 +61,16 @@ export const derive = <TState, TActions, TDerived>(
     };
   };
 
+  const listener = () => {
+    isStale = true;
+    listeners.forEach((listener) => listener(get()));
+  };
+
   const mount = () => {
     if (!unsubscribe) {
-      unsubscribe = store.subscribe(() => {
-        isStale = true;
-        listeners.forEach((listener) => listener(get()));
-      });
+      unsubscribe = store.subscribe(listener);
     }
+    return unmount;
   };
 
   const unmount = () => {

--- a/packages/dharma-core/src/types/types.ts
+++ b/packages/dharma-core/src/types/types.ts
@@ -13,12 +13,19 @@ export type Store<TState, TActions> = {
 
 export type DerivedStoreActions = {
   /** Start listening to changes in the original store. Called automatically on the first subscription. */
-  mount: () => void;
+  mount: () => () => void;
   /** Stop listening to changes in the original store. Called automatically when there are no more subscribers. */
   unmount: () => void;
 };
 
 export type DerivedStore<TState> = Store<TState, DerivedStoreActions>;
+
+export type Effect = {
+  /** Start listening to changes in the original store. */
+  mount: () => () => void;
+  /** Stop listening to changes in the original store. */
+  unmount: () => void;
+};
 
 export type StoreEventContext<TState> = {
   /** The current state of the store. */


### PR DESCRIPTION
## Description

Adds a new utility: `createStore`
It creates a side effect that runs when a the state of a store changes.

## Related issue(s)

closes #89 

## Checklist before merge

_Check for yes or N/A_

- [x] PR title has format `type: summary`\*
- [x] Changeset created if type is `feat` or `fix`
- [x] New code is covered by unit tests
- [x] Documentation updated

\*Valid types: feat, fix, chore, test, refactor, docs
