### PR TITLE
fix: rename `defineActions` to `actions`

### DIFF
--- a/.changeset/forty-houses-lead.md
+++ b/.changeset/forty-houses-lead.md
@@ -1,0 +1,5 @@
+---
+"dharma-core": minor
+---
+
+renamed defineActions to actions

--- a/.changeset/wide-spiders-juggle.md
+++ b/.changeset/wide-spiders-juggle.md
@@ -1,0 +1,5 @@
+---
+"dharma-react": patch
+---
+
+updated readme

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ import { createStore } from "dharma-core";
 
 const store = createStore({
   initialState: { count: 0 },
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
   }),
@@ -60,7 +60,7 @@ import { createStore } from "dharma-core";
 
 export const store = createStore({
   initialState: { count: 0 },
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
   }),

--- a/apps/docs/src/content/docs/core-concepts.mdx
+++ b/apps/docs/src/content/docs/core-concepts.mdx
@@ -19,7 +19,7 @@ import { createStore } from "dharma-core";
 
 const store = createStore({
   initialState: { count: 0 },
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
   }),
@@ -80,7 +80,7 @@ const store = createStore({
   persist: true,
   key: "counter", // Unique key for storage
   initialState: { count: 0 },
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
   }),
 });

--- a/apps/docs/src/content/docs/core/createstore.mdx
+++ b/apps/docs/src/content/docs/core/createstore.mdx
@@ -30,7 +30,7 @@ The `config` object can contain the following properties:
 **Setup**
 
 - `initialState` - The initial state of the store.
-- `defineActions` - A function that defines actions that can modify the state.
+- `actions` - A function that defines actions that can modify the state.
 
 **Lifecycle hooks**
 
@@ -61,7 +61,7 @@ import { createStore } from "dharma-core";
 
 const store = createStore({
   initialState: { count: 0 },
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
   }),
@@ -99,7 +99,7 @@ const store = createStore({
   persist: true,
   key: "count",
   initialState: { count: 0 },
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
   }),
@@ -118,7 +118,7 @@ const store = createStore({
   storage: sessionStorage,
   serializer: superjson,
   initialState: { count: 0 },
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
   }),

--- a/apps/docs/src/content/docs/core/merge.mdx
+++ b/apps/docs/src/content/docs/core/merge.mdx
@@ -30,7 +30,7 @@ const store = createStore({
     },
     // ...
   },
-  defineActions: ({ set }) => {
+  actions: ({ set }) => {
     const setCounter = (counter: StateModifier<{ count: number }>) =>
       set((state) => ({
         counter: merge(state.counter, counter),

--- a/apps/docs/src/content/docs/core/quick-start.mdx
+++ b/apps/docs/src/content/docs/core/quick-start.mdx
@@ -23,7 +23,7 @@ import PackageManager from "../../../components/PackageManager.astro";
 
    const store = createStore({
      initialState: { count: 0 },
-     defineActions: ({ set }) => ({
+     actions: ({ set }) => ({
        increment: () => set((state) => ({ count: state.count + 1 })),
        decrement: () => set((state) => ({ count: state.count - 1 })),
      }),

--- a/apps/docs/src/content/docs/react/createstorecontext.mdx
+++ b/apps/docs/src/content/docs/react/createstorecontext.mdx
@@ -24,7 +24,7 @@ import { useMemo } from "react";
 const createCounterStore = (initialCount: number) => {
   return createStore({
     initialState: { count: initialCount },
-    defineActions: ({ set }) => ({
+    actions: ({ set }) => ({
       increment: () => set((state) => ({ count: state.count + 1 })),
       decrement: () => set((state) => ({ count: state.count - 1 })),
     }),

--- a/apps/docs/src/content/docs/react/quick-start.mdx
+++ b/apps/docs/src/content/docs/react/quick-start.mdx
@@ -24,7 +24,7 @@ import PackageManager from "../../../components/PackageManager.astro";
 
    export const store = createStore({
      initialState: { count: 0 },
-     defineActions: ({ set }) => ({
+     actions: ({ set }) => ({
        increment: () => set((state) => ({ count: state.count + 1 })),
        decrement: () => set((state) => ({ count: state.count - 1 })),
      }),

--- a/apps/sandbox/src/components/examples/AsyncExample.tsx
+++ b/apps/sandbox/src/components/examples/AsyncExample.tsx
@@ -28,7 +28,7 @@ const initialState: State = {
 
 const store = createStore({
   initialState,
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     refresh: async () => {
       set({ users: [], loading: true });
       const users = await fetchUsers();

--- a/apps/sandbox/src/components/examples/ContextExample.tsx
+++ b/apps/sandbox/src/components/examples/ContextExample.tsx
@@ -14,7 +14,7 @@ interface TodoState {
 const createTodoStore = (initialState: TodoState) => {
   return createStore({
     initialState,
-    defineActions: ({ set, get }) => ({
+    actions: ({ set, get }) => ({
       setInput: (input: string) => set({ input }),
       addTodo: () => {
         if (!get().input) {

--- a/apps/sandbox/src/components/examples/CounterExample.tsx
+++ b/apps/sandbox/src/components/examples/CounterExample.tsx
@@ -5,7 +5,7 @@ import { Button } from "../ui/button";
 // Create the store
 const store = createStore({
   initialState: { count: 0 },
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
   }),

--- a/apps/sandbox/src/components/examples/DerivedExample.tsx
+++ b/apps/sandbox/src/components/examples/DerivedExample.tsx
@@ -5,7 +5,7 @@ import { Input } from "../ui/input";
 
 const store = createStore({
   initialState: { count: 0, input: "" },
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
     setInput: (input: string) => set({ input }),
@@ -16,7 +16,7 @@ const { increment, decrement, setInput } = store.actions;
 
 const computationCounter = createStore({
   initialState: 0,
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => state + 1),
   }),
 });

--- a/apps/sandbox/src/components/examples/EffectExample.tsx
+++ b/apps/sandbox/src/components/examples/EffectExample.tsx
@@ -6,7 +6,7 @@ import { Input } from "../ui/input";
 
 const store = createStore({
   initialState: { count: 0, input: "" },
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
     setInput: (input: string) => set({ input }),

--- a/apps/sandbox/src/components/examples/PersistentAsyncExample.tsx
+++ b/apps/sandbox/src/components/examples/PersistentAsyncExample.tsx
@@ -9,7 +9,7 @@ const store = createStore({
   persist: true,
   initialState: { count: 0 },
   storage: AsyncStorage,
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
   }),

--- a/apps/sandbox/src/components/examples/PersistentExample.tsx
+++ b/apps/sandbox/src/components/examples/PersistentExample.tsx
@@ -9,7 +9,7 @@ const store = createStore({
   key: "count",
   persist: true,
   initialState: { count: 0 },
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
   }),

--- a/apps/sandbox/src/components/examples/SharedExample.tsx
+++ b/apps/sandbox/src/components/examples/SharedExample.tsx
@@ -38,7 +38,7 @@ const useRenderCount = () => {
 
 const sharedStore = createStore({
   initialState,
-  defineActions: ({ set, get }) => {
+  actions: ({ set, get }) => {
     const setCountState = (countState: StateModifier<CountState>) =>
       set((state) => ({
         countState: merge(state.countState, countState),

--- a/apps/sandbox/src/components/examples/TodoExample.tsx
+++ b/apps/sandbox/src/components/examples/TodoExample.tsx
@@ -19,7 +19,7 @@ const initialState: TodoState = {
 
 const store = createStore({
   initialState,
-  defineActions: ({ set, get }) => ({
+  actions: ({ set, get }) => ({
     setInput: (input: string) => set({ input }),
     addTodo: () => {
       if (!get().input) {

--- a/apps/sandbox/src/pages/vanilla.astro
+++ b/apps/sandbox/src/pages/vanilla.astro
@@ -16,7 +16,7 @@ import Layout from '../layouts/Layout.astro';
 
   const store = createStore({
     initialState: { count: 0 },
-    defineActions: ({ set }) => ({
+    actions: ({ set }) => ({
       increment: () => set((state) => ({ count: state.count + 1 })),
       decrement: () => set((state) => ({ count: state.count - 1 })),
     }),

--- a/packages/dharma-core/CHANGELOG.md
+++ b/packages/dharma-core/CHANGELOG.md
@@ -88,7 +88,7 @@
 
 ### Minor Changes
 
-- [#8](https://github.com/fransek/dharma/pull/8) [`2060d71`](https://github.com/fransek/dharma/commit/2060d71fbbecba7d37f658f03fdfd9d1f49bc275) Thanks [@fransek](https://github.com/fransek)! - Event handler and defineActions arguments consolidated to an object
+- [#8](https://github.com/fransek/dharma/pull/8) [`2060d71`](https://github.com/fransek/dharma/commit/2060d71fbbecba7d37f658f03fdfd9d1f49bc275) Thanks [@fransek](https://github.com/fransek)! - Event handler and actions arguments consolidated to an object
 
 - [#8](https://github.com/fransek/dharma/pull/8) [`2060d71`](https://github.com/fransek/dharma/commit/2060d71fbbecba7d37f658f03fdfd9d1f49bc275) Thanks [@fransek](https://github.com/fransek)! - Consolidated createStore arguments to one configuration object
 

--- a/packages/dharma-core/README.md
+++ b/packages/dharma-core/README.md
@@ -13,7 +13,7 @@ import { createStore } from "dharma-core";
 
 const store = createStore({
   initialState: { count: 0 },
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
   }),

--- a/packages/dharma-core/src/lib/createEffect.test.ts
+++ b/packages/dharma-core/src/lib/createEffect.test.ts
@@ -8,7 +8,7 @@ describe("createEffect", () => {
 
   const store = createStore({
     initialState: { count: 0, other: "foo" },
-    defineActions: ({ set, reset }) => ({
+    actions: ({ set, reset }) => ({
       increment: () => set((state) => ({ count: state.count + 1 })),
       decrement: () => set((state) => ({ count: state.count - 1 })),
       reset: () => reset(),

--- a/packages/dharma-core/src/lib/createStore.node.test.ts
+++ b/packages/dharma-core/src/lib/createStore.node.test.ts
@@ -9,7 +9,7 @@ describe("createStore (node)", () => {
     persist: true,
     key: "test",
     initialState: { count: 0 },
-    defineActions: <T>(ctx: ActionContext<T>) => ctx,
+    actions: <T>(ctx: ActionContext<T>) => ctx,
   };
 
   it("should not throw in a node environment", () => {

--- a/packages/dharma-core/src/lib/createStore.test.ts
+++ b/packages/dharma-core/src/lib/createStore.test.ts
@@ -5,10 +5,10 @@ import { createStore } from "./createStore";
 
 describe("createStore", () => {
   const initialState = { count: 0 };
-  const defineActions = <T>(ctx: ActionContext<T>) => ctx;
+  const actions = <T>(ctx: ActionContext<T>) => ctx;
   const store = createStore({
     initialState,
-    defineActions,
+    actions,
   });
 
   afterEach(store.actions.reset);
@@ -42,7 +42,7 @@ describe("createStore", () => {
   it("should create actions if provided", () => {
     const store = createStore({
       initialState: { count: 0 },
-      defineActions: ({ set, get, reset }) => ({
+      actions: ({ set, get, reset }) => ({
         increment: () => set((state) => ({ count: state.count + 1 })),
         getCount: () => get().count,
         resetCount: () => reset(),
@@ -65,7 +65,7 @@ describe("createStore", () => {
     const initialState = { count: 0, other: "foo" };
     const store = createStore({
       initialState,
-      defineActions,
+      actions,
       onChange: ({ state, set }) => set({ other: state.other + "bar" }),
     });
     store.actions.set({ count: 1 });
@@ -76,7 +76,7 @@ describe("createStore", () => {
     const initialState = { count: 0 };
     const store = createStore({
       initialState,
-      defineActions,
+      actions,
       onAttach: ({ state, set }) => set({ count: state.count + 1 }),
     });
     const listener = vi.fn();
@@ -88,7 +88,7 @@ describe("createStore", () => {
     const initialState = { count: 0 };
     const store = createStore({
       initialState,
-      defineActions,
+      actions,
       onDetach: ({ state, set }) => set({ count: state.count + 1 }),
     });
     const listener = vi.fn();
@@ -101,7 +101,7 @@ describe("createStore", () => {
     const initialState = { count: 0 };
     const store = createStore({
       initialState,
-      defineActions,
+      actions,
       onLoad: ({ state, set }) => set({ count: state.count + 1 }),
     });
     expect(store.get().count).toBe(1);
@@ -111,7 +111,7 @@ describe("createStore", () => {
     it("should update the state", () => {
       const store = createStore({
         initialState: 0,
-        defineActions,
+        actions,
       });
       store.actions.set(1);
       expect(store.get()).toBe(1);
@@ -120,7 +120,7 @@ describe("createStore", () => {
     it("should update the state with a function", () => {
       const store = createStore({
         initialState: 0,
-        defineActions,
+        actions,
       });
       store.actions.set((state) => state + 1);
       expect(store.get()).toBe(1);
@@ -143,7 +143,7 @@ describe("createStore", () => {
         persist: true,
         key,
         initialState,
-        defineActions,
+        actions,
       });
       expect(store.get()).toEqual(initialState);
     });
@@ -153,7 +153,7 @@ describe("createStore", () => {
         persist: true,
         key,
         initialState,
-        defineActions,
+        actions,
       });
       store.subscribe(listener);
       store.actions.set({ count: 1 });
@@ -168,7 +168,7 @@ describe("createStore", () => {
         persist: true,
         key,
         initialState,
-        defineActions,
+        actions,
       });
       expect(store.get()).toEqual({ count: 0 });
       store.subscribe(listener);
@@ -182,7 +182,7 @@ describe("createStore", () => {
         persist: true,
         key,
         initialState,
-        defineActions,
+        actions,
         storage: sessionStorage,
       });
       store.subscribe(listener);
@@ -194,7 +194,7 @@ describe("createStore", () => {
         persist: true,
         key,
         initialState,
-        defineActions,
+        actions,
       });
       store.subscribe(listener);
       store.actions.set({ count: 1 });
@@ -210,7 +210,7 @@ describe("createStore", () => {
         persist: true,
         key,
         initialState,
-        defineActions,
+        actions,
       });
       const unsubscribe = store.subscribe(vi.fn());
       const unsubscribe2 = store.subscribe(vi.fn());
@@ -229,7 +229,7 @@ describe("createStore", () => {
         persist: true,
         key,
         initialState,
-        defineActions,
+        actions,
         serializer: customSerializer,
       });
       store.actions.set({ count: 1 });
@@ -246,7 +246,7 @@ describe("createStore", () => {
         persist: true,
         key,
         initialState,
-        defineActions,
+        actions,
         storage: customStorage,
       });
       store.actions.set({ count: 1 });
@@ -264,7 +264,7 @@ describe("createStore", () => {
         persist: true,
         key,
         initialState,
-        defineActions,
+        actions,
         storage: AsyncStorage,
       });
       store.subscribe(listener);

--- a/packages/dharma-core/src/lib/createStore.ts
+++ b/packages/dharma-core/src/lib/createStore.ts
@@ -14,8 +14,14 @@ import { merge } from "./merge";
 export const createStore = <TState, TActions = undefined>(
   config: StoreConfig<TState, TActions>,
 ): Store<TState, TActions> => {
-  const { initialState, defineActions, onLoad, onAttach, onDetach, onChange } =
-    config;
+  const {
+    initialState,
+    actions: createActions,
+    onLoad,
+    onAttach,
+    onDetach,
+    onChange,
+  } = config;
 
   let state = initialState;
 
@@ -41,7 +47,7 @@ export const createStore = <TState, TActions = undefined>(
   };
 
   const listeners = new Set<Listener<TState>>();
-  const actions = defineActions?.({ set, get, reset }) as TActions;
+  const actions = createActions?.({ set, get, reset }) as TActions;
   const storageAdapter = createStorageAdapter(config, get, set);
 
   const subscribe = (listener: Listener<TState>) => {

--- a/packages/dharma-core/src/lib/derive.test.ts
+++ b/packages/dharma-core/src/lib/derive.test.ts
@@ -10,7 +10,7 @@ describe("derive", () => {
 
   const store = createStore({
     initialState: { count: 0, other: "foo" },
-    defineActions: ({ set, reset }) => ({
+    actions: ({ set, reset }) => ({
       increment: () => set((state) => ({ count: state.count + 1 })),
       decrement: () => set((state) => ({ count: state.count - 1 })),
       reset: () => reset(),

--- a/packages/dharma-core/src/types/types.ts
+++ b/packages/dharma-core/src/types/types.ts
@@ -53,7 +53,7 @@ export type ActionContext<TState> = {
   reset: () => TState;
 };
 
-export type DefineActions<TState, TActions> = (
+export type actions<TState, TActions> = (
   context: ActionContext<TState>,
 ) => TActions;
 
@@ -61,7 +61,7 @@ export type BaseConfig<TState, TActions> = {
   /** The initial state of the store. */
   initialState: TState;
   /** A function that defines actions that can modify the state. */
-  defineActions?: DefineActions<TState, TActions>;
+  actions?: actions<TState, TActions>;
   /** Invoked when the store is created. */
   onLoad?: StoreEventListener<TState>;
   /** Invoked when the store is subscribed to. */

--- a/packages/dharma-react/README.md
+++ b/packages/dharma-react/README.md
@@ -25,7 +25,7 @@ import { createStore } from "dharma-core";
 
 export const store = createStore({
   initialState: { count: 0 },
-  defineActions: ({ set }) => ({
+  actions: ({ set }) => ({
     increment: () => set((state) => ({ count: state.count + 1 })),
     decrement: () => set((state) => ({ count: state.count - 1 })),
   }),

--- a/packages/dharma-react/src/lib/useStore.test.tsx
+++ b/packages/dharma-react/src/lib/useStore.test.tsx
@@ -14,7 +14,7 @@ const useRenderCount = () => {
 describe("useStore", () => {
   const store = createStore({
     initialState: { count: 0 },
-    defineActions: ({ set }) => ({
+    actions: ({ set }) => ({
       increment: () => set((state) => ({ count: state.count + 1 })),
       decrement: () => set((state) => ({ count: state.count - 1 })),
       reset: () => set({ count: 0 }),
@@ -46,7 +46,7 @@ describe("useStore", () => {
   it("should return the selected state and only re-render when the selected state changes", async () => {
     const testStore = createStore({
       initialState: { count: 0, foo: 0 },
-      defineActions: ({ set }) => ({
+      actions: ({ set }) => ({
         increaseCount: () => set((state) => ({ count: state.count + 1 })),
         increaseFoo: () => set((state) => ({ foo: state.foo + 1 })),
       }),

--- a/packages/dharma-react/src/lib/useStoreContext.test.tsx
+++ b/packages/dharma-react/src/lib/useStoreContext.test.tsx
@@ -9,7 +9,7 @@ describe("useStoreContext", () => {
   const create = (initialCount: number) =>
     createStore({
       initialState: { count: initialCount },
-      defineActions: ({ set }) => ({
+      actions: ({ set }) => ({
         increment: () => set((state) => ({ count: state.count + 1 })),
         decrement: () => set((state) => ({ count: state.count - 1 })),
       }),


### PR DESCRIPTION
## Description

Renames `defineActions` to `actions` to reduce verbosity.

## Related issue(s)

## Checklist before merge

_Check for yes or N/A_

- [x] PR title has format `type: summary`\*
- [x] Changeset created if type is `feat` or `fix`
- [x] New code is covered by unit tests
- [x] Documentation updated

\*Valid types: feat, fix, chore, test, refactor, docs
