### PR TITLE
fix: peer deps

### DIFF
--- a/.changeset/witty-points-wave.md
+++ b/.changeset/witty-points-wave.md
@@ -1,0 +1,5 @@
+---
+"dharma-react": patch
+---
+
+adjusted peer dependencies

--- a/packages/dharma-react/package.json
+++ b/packages/dharma-react/package.json
@@ -66,6 +66,19 @@
     "react": "^19.1.1"
   },
   "peerDependencies": {
-    "react": "^19.1.1"
+    "dharma-core": "0.11.0",
+    "react": ">=18.0.0",
+    "@types/react": ">=18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "dharma-core": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "@types/react": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
## Description

- Adds @types/react and dharma-core as peer dependencies
- Sets earliest react version to 18
- Sets all peer dependencies as optional

## Related issue(s)

## Checklist before merge

_Check for yes or N/A_

- [x] PR title has format `type: summary`\*
- [x] Changeset created if type is `feat` or `fix`
- [x] New code is covered by unit tests
- [x] Documentation updated

\*Valid types: feat, fix, chore, test, refactor, docs
