### PR TITLE
feat: extend useStoreContext API

### DIFF
--- a/.changeset/sixty-horses-jump.md
+++ b/.changeset/sixty-horses-jump.md
@@ -1,0 +1,5 @@
+---
+"dharma-react": minor
+---
+
+Extended `useStoreContext` to return the full store API along with the reactive state

--- a/apps/docs/src/content/docs/react/usestore.mdx
+++ b/apps/docs/src/content/docs/react/usestore.mdx
@@ -47,7 +47,6 @@ function Counter() {
 const count = useStore(store, (state) => state.count);
 ```
 
-**Note:** If the `select` function is provided, an equality check is performed. This has some caveats:
-
-- For optimal performance, return a direct reference to the state. (e.g. `state.count`)
-- If you return an object literal, it should only contain direct references to the state. (e.g. `{ count: state.count }`)
+**Note:** If the `select` function is provided, an equality check is performed. For optimal performance, return a direct reference to the state. (e.g. `state.count`)
+If you wish to select multiple values, return an object or an array. (e.g. `{ count: state.count, name: state.name }` or `[state.count, state.name]`)
+Other unstable reference types will cause infinite loops.

--- a/apps/docs/src/content/docs/react/usestorecontext.mdx
+++ b/apps/docs/src/content/docs/react/usestorecontext.mdx
@@ -20,7 +20,12 @@ const store = useStoreContext(StoreContext, select?);
 The store instance.
 
 - `state` - The current state of the store.
-- `actions` - The actions that can modify the state of the store.
+- `get` - Returns the current state of the store.
+- `set` - Sets the state of the store.
+- `reset` - Resets the state of the store to its initial value.
+- `initialState` - The initial state of the store.
+- `actions` - Actions that can modify the state of the store (if provided).
+- `subscribe` - Subscribes to changes in the state of the store. Returns an unsubscribe function.
 
 ## Usage
 
@@ -52,7 +57,6 @@ function Counter() {
 const { state: count } = useStoreContext(StoreContext, (state) => state.count);
 ```
 
-If the `select` function is provided, an equality check is performed. This has some caveats:
-
-- For optimal performance, return a direct reference to the state. (e.g. `state.count`)
-- If you return an object literal, it should only contain direct references to the state. (e.g. `{ count: state.count }`)
+**Note:** If the `select` function is provided, an equality check is performed. For optimal performance, return a direct reference to the state. (e.g. `state.count`)
+If you wish to select multiple values, return an object or an array. (e.g. `{ count: state.count, name: state.name }` or `[state.count, state.name]`)
+Other unstable reference types will cause infinite loops.

--- a/packages/dharma-react/src/lib/useStoreContext.test.tsx
+++ b/packages/dharma-react/src/lib/useStoreContext.test.tsx
@@ -45,6 +45,13 @@ describe("useStoreContext", () => {
         increment: expect.any(Function),
         decrement: expect.any(Function),
       },
+      get: expect.any(Function),
+      reset: expect.any(Function),
+      set: expect.any(Function),
+      subscribe: expect.any(Function),
+      initialState: {
+        count: 0,
+      },
     });
   });
 

--- a/packages/dharma-react/src/lib/useStoreContext.ts
+++ b/packages/dharma-react/src/lib/useStoreContext.ts
@@ -30,8 +30,5 @@ export const useStoreContext = <
       "[dharma-react] Store context not found. Make sure you are using the store context within a provider.",
     );
   }
-  return {
-    state: useStore(store, select),
-    actions: store.actions,
-  };
+  return { ...store, state: useStore(store, select) };
 };

--- a/packages/dharma-react/src/types/types.ts
+++ b/packages/dharma-react/src/types/types.ts
@@ -6,7 +6,9 @@ export type StoreContext<
   TStoreCreator extends (...args: any[]) => Store<any, any>,
 > = Context<ReturnType<TStoreCreator> | null>;
 
-export type BoundStore<TState, TActions, TSelection = TState> = {
+export type BoundStore<TState, TActions, TSelection = TState> = Store<
+  TState,
+  TActions
+> & {
   state: TSelection;
-  actions: TActions;
 };

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,9 @@ packages:
   - packages/*
   - apps/*
 
+allowBuilds:
+  esbuild: true
+  sharp: true
+
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## Description

Extends the `useStoreContext` API so it now returns the full store interface in addition to the selected `state`. Previously only `state` and `actions` were returned.

The returned object now spreads the entire store, exposing:

- `get` - Returns the current state of the store.
- `set` - Sets the state of the store.
- `reset` - Resets the state of the store to its initial value.
- `initialState` - The initial state of the store.
- `actions` - Actions that can modify the state of the store (if provided).
- `subscribe` - Subscribes to changes in the state of the store. Returns an unsubscribe function.

`BoundStore` is updated to intersect the full `Store<TState, TActions>` type with the selected `state`.

Also:
- Updated the `useStore` and `useStoreContext` docs to clarify selecting multiple values (return an object or array) and to warn that unstable reference types cause infinite loops.
- Added `allowBuilds` (esbuild, sharp) to `pnpm-workspace.yaml`.

## Related issue(s)

## Checklist before merge

_Check for yes or N/A_

- [x] PR title has format `type: summary`*
- [x] Changeset created if type is `feat` or `fix`
- [x] New code is covered by unit tests
- [x] Documentation updated

\*Valid types: feat, fix, chore, test, refactor, docs
